### PR TITLE
Remove srgn tool reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,8 +243,6 @@ The following tooling is available in this environment:
 - `fd` – Fast, user-friendly `find` alternative with sensible defaults.
 - `checkmake` – Linter for `Makefile`s, ensuring they follow best practices and
   conventions.
-- `srgn` – [Structural grep](https://github.com/alexpovel/srgn), searches code
-  and enables editing by syntax tree patterns.
 - `difft` **(Difftastic)** – Semantic diff tool that compares code structure
   rather than just text differences.
 


### PR DESCRIPTION
## Summary
- remove outdated srgn tool reference from AGENTS

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68c1c871961483229c2c50f1d0ccac18

## Summary by Sourcery

Documentation:
- Remove the `srgn` entry from AGENTS.md