### PR TITLE
Add DenseMatrixProvider for Arrow ingestion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,26 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.3",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +32,216 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "arrow-array"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8548ca7c070d8db9ce7aa43f37393e4bfcf3f2d3681df278490772fd1673d08d"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.0",
+ "num",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+dependencies = [
+ "bytes",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "919418a0681298d3a77d1a315f625916cb5678ad0d74b9c60108eb15fd083023"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5c64fff1d142f833d78897a772f2e5b55b36cb3e6320376f0961ab0db7bd6d0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3594dcddccc7f20fd069bc8e9828ce37220372680ff638c5e00dea427d88f5"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
+
+[[package]]
+name = "arrow-select"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c41dbbd1e97bfcaee4fcb30e29105fb2c75e4d82ae4de70b792a5d3f66b2e7a"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "chrono"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "chutoro-cli"
@@ -36,8 +262,13 @@ dependencies = [
 name = "chutoro-providers-dense"
 version = "0.1.0"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
+ "bytes",
  "chutoro-core",
+ "parquet",
  "rstest",
+ "thiserror",
 ]
 
 [[package]]
@@ -49,10 +280,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "flatbuffers"
+version = "25.9.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b6620799e7340ebd9968d2e0708eb82cf1971e9a16821e2091b6d6e475eed5"
+dependencies = [
+ "bitflags",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "libz-rs-sys",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "futures"
@@ -150,10 +449,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+]
 
 [[package]]
 name = "hashbrown"
@@ -162,13 +495,162 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.176"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "840db8cf39d9ec4dd794376f38acc40d0fc65eec2a8f484f7fd375b84602becd"
+dependencies = [
+ "zlib-rs",
+]
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -176,6 +658,143 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "parquet"
+version = "56.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dbd48ad52d7dccf8ea1b90a3ddbfaea4f69878dd7683e51c507d4bc52b5b27"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "half",
+ "hashbrown 0.16.0",
+ "lz4_flex",
+ "num",
+ "num-bigint",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pin-project-lite"
@@ -188,6 +807,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "proc-macro-crate"
@@ -215,6 +840,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -291,16 +922,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "syn"
@@ -334,6 +1001,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,10 +1038,164 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "winnow"
@@ -363,4 +1204,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f06ae92f42f5e5c42443fd094f245eb656abf56dd7cce9b8b263236565e00f2"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/chutoro-providers/dense/Cargo.toml
+++ b/chutoro-providers/dense/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+arrow-array = "56.2.0"
+arrow-schema = "56.2.0"
+parquet = { version = "56.2.0", features = ["arrow"] }
+thiserror = "1.0"
 [dependencies.chutoro-core]
 version = "0.1.0"
 path = "../../chutoro-core"
@@ -11,4 +15,5 @@ default-features = false
 features = ["skeleton"]
 
 [dev-dependencies]
+bytes = "1.10"
 rstest = "0.23"

--- a/chutoro-providers/dense/src/lib.rs
+++ b/chutoro-providers/dense/src/lib.rs
@@ -1,5 +1,12 @@
-//! Dense provider for in-memory f32 vectors implementing DataSource.
+//! Dense providers for f32 vectors backed by contiguous storage.
+use std::{fs::File, path::Path};
+
+use arrow_array::{Array, FixedSizeListArray, Float32Array, RecordBatchReader};
+use arrow_schema::{ArrowError, DataType};
 use chutoro_core::{DataSource, DataSourceError};
+use parquet::arrow::{ProjectionMask, arrow_reader::ParquetRecordBatchReaderBuilder};
+use parquet::file::reader::ChunkReader;
+use thiserror::Error;
 
 /// In-memory dense vector data source.
 pub struct DenseSource {
@@ -95,11 +102,273 @@ impl DataSource for DenseSource {
     }
 }
 
+/// Dense matrix provider backed by a contiguous row-major buffer.
+///
+/// # Examples
+/// ```
+/// use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+/// use chutoro_providers_dense::DenseMatrixProvider;
+/// use chutoro_core::DataSource;
+///
+/// let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), 2);
+/// builder.values().append_value(1.0);
+/// builder.values().append_value(2.0);
+/// builder.append(true);
+/// let array = builder.finish();
+///
+/// let provider = DenseMatrixProvider::try_from_fixed_size_list("demo", &array).unwrap();
+/// assert_eq!(provider.len(), 1);
+/// assert_eq!(provider.dimension(), 2);
+/// assert_eq!(provider.data(), &[1.0, 2.0]);
+/// ```
+#[derive(Debug)]
+pub struct DenseMatrixProvider {
+    name: String,
+    rows: usize,
+    dimension: usize,
+    values: Vec<f32>,
+}
+
+impl DenseMatrixProvider {
+    /// Creates a provider from a contiguous matrix.
+    fn from_parts(
+        name: impl Into<String>,
+        rows: usize,
+        dimension: usize,
+        values: Vec<f32>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            rows,
+            dimension,
+            values,
+        }
+    }
+
+    /// Returns the dimensionality of each row.
+    #[must_use]
+    pub fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    /// Returns the underlying row-major matrix.
+    #[must_use]
+    pub fn data(&self) -> &[f32] {
+        &self.values
+    }
+
+    /// Loads data from an Arrow [`FixedSizeListArray`].
+    pub fn try_from_fixed_size_list(
+        name: impl Into<String>,
+        array: &FixedSizeListArray,
+    ) -> Result<Self, DenseMatrixProviderError> {
+        let dimension = validate_fixed_size_list(array)?;
+        let mut values = Vec::with_capacity(array.len() * dimension);
+        copy_list_values(array, dimension, 0, &mut values)?;
+        Ok(Self::from_parts(name, array.len(), dimension, values))
+    }
+
+    /// Loads data from a Parquet column containing `FixedSizeList<Float32, D>` rows.
+    pub fn try_from_parquet_path(
+        name: impl Into<String>,
+        path: impl AsRef<Path>,
+        column: &str,
+    ) -> Result<Self, DenseMatrixProviderError> {
+        let file = File::open(path)?;
+        Self::try_from_parquet_reader(name, file, column)
+    }
+
+    /// Loads data from a Parquet reader.
+    pub fn try_from_parquet_reader<R>(
+        name: impl Into<String>,
+        reader: R,
+        column: &str,
+    ) -> Result<Self, DenseMatrixProviderError>
+    where
+        R: ChunkReader + Send + 'static,
+    {
+        let builder = ParquetRecordBatchReaderBuilder::try_new(reader)?;
+        let mask = ProjectionMask::columns(builder.parquet_schema(), [column]);
+        let reader = builder.with_projection(mask).build()?;
+        let schema = reader.schema();
+        let column_index =
+            schema
+                .index_of(column)
+                .map_err(|_| DenseMatrixProviderError::ColumnNotFound {
+                    column: column.to_owned(),
+                })?;
+        let field = schema.field(column_index);
+        let width = match field.data_type() {
+            DataType::FixedSizeList(child, width) => {
+                if child.data_type() != &DataType::Float32 {
+                    return Err(DenseMatrixProviderError::InvalidListValueType {
+                        actual: child.data_type().clone(),
+                    });
+                }
+                *width
+            }
+            other => {
+                return Err(DenseMatrixProviderError::InvalidColumnType {
+                    column: column.to_owned(),
+                    actual: other.clone(),
+                });
+            }
+        };
+        let dimension = usize::try_from(width)
+            .map_err(|_| DenseMatrixProviderError::InvalidDimension { actual: width })?;
+        let mut values = Vec::new();
+        let mut rows = 0_usize;
+        for batch in reader {
+            let batch = batch?;
+            let column_array = batch.column(column_index);
+            let list = column_array
+                .as_any()
+                .downcast_ref::<FixedSizeListArray>()
+                .ok_or_else(|| DenseMatrixProviderError::InvalidColumnType {
+                    column: column.to_owned(),
+                    actual: column_array.data_type().clone(),
+                })?;
+            let list_width = usize::try_from(list.value_length()).map_err(|_| {
+                DenseMatrixProviderError::InvalidDimension {
+                    actual: list.value_length(),
+                }
+            })?;
+            if list_width != dimension {
+                return Err(DenseMatrixProviderError::InconsistentBatchDimension {
+                    expected: dimension,
+                    actual: list_width,
+                });
+            }
+            copy_list_values(list, dimension, rows, &mut values)?;
+            rows += list.len();
+        }
+        Ok(Self::from_parts(name, rows, dimension, values))
+    }
+
+    fn row_slice(&self, index: usize) -> Result<&[f32], DataSourceError> {
+        if index >= self.rows {
+            return Err(DataSourceError::OutOfBounds { index });
+        }
+        let start = index * self.dimension;
+        let end = start + self.dimension;
+        Ok(&self.values[start..end])
+    }
+}
+
+impl DataSource for DenseMatrixProvider {
+    fn len(&self) -> usize {
+        self.rows
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    #[expect(clippy::float_arithmetic, reason = "vector arithmetic")]
+    fn distance(&self, i: usize, j: usize) -> Result<f32, DataSourceError> {
+        let a = self.row_slice(i)?;
+        let b = self.row_slice(j)?;
+        let mut sum = 0.0_f32;
+        for idx in 0..self.dimension {
+            let diff = a[idx] - b[idx];
+            sum += diff * diff;
+        }
+        Ok(sum.sqrt())
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum DenseMatrixProviderError {
+    #[error("column `{column}` not found in Parquet schema")]
+    ColumnNotFound { column: String },
+    #[error("column `{column}` must be a FixedSizeList<Float32, _> but found {actual:?}")]
+    InvalidColumnType { column: String, actual: DataType },
+    #[error("FixedSizeList child type must be Float32 but found {actual:?}")]
+    InvalidListValueType { actual: DataType },
+    #[error("invalid FixedSizeList dimension {actual}")]
+    InvalidDimension { actual: i32 },
+    #[error("row {row} is null")]
+    NullRow { row: usize },
+    #[error("row {row} contains null value at position {value_index}")]
+    NullValue { row: usize, value_index: usize },
+    #[error("row {row} has length {actual} but expected {expected}")]
+    InvalidRowLength {
+        row: usize,
+        expected: usize,
+        actual: usize,
+    },
+    #[error("inconsistent dimensions across batches: expected {expected}, got {actual}")]
+    InconsistentBatchDimension { expected: usize, actual: usize },
+    #[error("arrow error: {0}")]
+    Arrow(#[from] ArrowError),
+    #[error("parquet error: {0}")]
+    Parquet(#[from] parquet::errors::ParquetError),
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+fn validate_fixed_size_list(array: &FixedSizeListArray) -> Result<usize, DenseMatrixProviderError> {
+    let value_type = array.value_type();
+    if value_type != DataType::Float32 {
+        return Err(DenseMatrixProviderError::InvalidListValueType { actual: value_type });
+    }
+    usize::try_from(array.value_length()).map_err(|_| DenseMatrixProviderError::InvalidDimension {
+        actual: array.value_length(),
+    })
+}
+
+fn copy_list_values(
+    array: &FixedSizeListArray,
+    dimension: usize,
+    start_row: usize,
+    out: &mut Vec<f32>,
+) -> Result<usize, DenseMatrixProviderError> {
+    out.reserve(array.len() * dimension);
+    for row_index in 0..array.len() {
+        let absolute_row = start_row + row_index;
+        if array.is_null(row_index) {
+            return Err(DenseMatrixProviderError::NullRow { row: absolute_row });
+        }
+        let row = array.value(row_index);
+        let floats = row.as_any().downcast_ref::<Float32Array>().ok_or_else(|| {
+            DenseMatrixProviderError::InvalidListValueType {
+                actual: row.data_type().clone(),
+            }
+        })?;
+        if floats.len() != dimension {
+            return Err(DenseMatrixProviderError::InvalidRowLength {
+                row: absolute_row,
+                expected: dimension,
+                actual: floats.len(),
+            });
+        }
+        if floats.null_count() > 0 {
+            let value_index = (0..dimension)
+                .find(|&idx| floats.is_null(idx))
+                .unwrap_or_default();
+            return Err(DenseMatrixProviderError::NullValue {
+                row: absolute_row,
+                value_index,
+            });
+        }
+        for idx in 0..dimension {
+            out.push(floats.value(idx));
+        }
+    }
+    Ok(array.len())
+}
+
 #[cfg(test)]
 #[expect(clippy::expect_used, reason = "tests require contextual panics")]
 mod tests {
     use super::*;
+    use arrow_array::builder::{FixedSizeListBuilder, Float32Builder};
+    use arrow_array::{ArrayRef, RecordBatch};
+    use arrow_schema::{DataType, Field, Schema};
+    use bytes::Bytes;
+    use parquet::arrow::arrow_writer::ArrowWriter;
     use rstest::rstest;
+    use std::sync::Arc;
 
     #[rstest]
     fn distance_dimension_mismatch() {
@@ -136,5 +405,142 @@ mod tests {
             .expect("valid uniform rows");
         let d = ds.distance(0, 1).expect("distance must succeed");
         assert!((d - 5.0).abs() < 1e-6);
+    }
+
+    fn build_array(rows: &[[f32; 3]]) -> FixedSizeListArray {
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), 3);
+        for row in rows {
+            for value in row {
+                builder.values().append_value(*value);
+            }
+            builder.append(true);
+        }
+        builder.finish()
+    }
+
+    #[rstest]
+    fn matrix_provider_from_fixed_size_list() {
+        let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let provider =
+            DenseMatrixProvider::try_from_fixed_size_list("demo", &array).expect("valid matrix");
+        assert_eq!(provider.len(), 2);
+        assert_eq!(provider.dimension(), 3);
+        assert_eq!(provider.data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let distance = provider.distance(0, 1).expect("distance should work");
+        assert!((distance - (27.0_f32).sqrt()).abs() < 1e-6);
+    }
+
+    #[rstest]
+    fn matrix_provider_rejects_null_rows() {
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), 2);
+        builder.values().append_value(1.0);
+        builder.values().append_value(2.0);
+        builder.append(true);
+        builder.values().append_null();
+        builder.values().append_null();
+        builder.append(false);
+        let array = builder.finish();
+        let err = DenseMatrixProvider::try_from_fixed_size_list("demo", &array)
+            .expect_err("null rows must be rejected");
+        assert!(matches!(err, DenseMatrixProviderError::NullRow { row: 1 }));
+    }
+
+    #[rstest]
+    fn matrix_provider_rejects_null_values() {
+        let mut builder = FixedSizeListBuilder::new(Float32Builder::new(), 2);
+        builder.values().append_value(1.0);
+        builder.values().append_value(2.0);
+        builder.append(true);
+        builder.values().append_value(3.0);
+        builder.values().append_null();
+        builder.append(true);
+        let array = builder.finish();
+        let err = DenseMatrixProvider::try_from_fixed_size_list("demo", &array)
+            .expect_err("null values must be rejected");
+        assert!(matches!(
+            err,
+            DenseMatrixProviderError::NullValue {
+                row: 1,
+                value_index: 1
+            }
+        ));
+    }
+
+    #[rstest]
+    fn matrix_provider_rejects_non_float_children() {
+        let field = Arc::new(Field::new("item", DataType::Int32, true));
+        let values: ArrayRef = Arc::new(arrow_array::Int32Array::from(vec![1, 2, 3, 4]));
+        let array = FixedSizeListArray::new(field, 2, values, None);
+        let err = DenseMatrixProvider::try_from_fixed_size_list("demo", &array)
+            .expect_err("non-float children must be rejected");
+        assert!(matches!(
+            err,
+            DenseMatrixProviderError::InvalidListValueType { .. }
+        ));
+    }
+
+    fn write_parquet(array: FixedSizeListArray) -> Bytes {
+        let field = Field::new(
+            "features",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 3),
+            false,
+        );
+        let schema = Arc::new(Schema::new(vec![field]));
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(array) as ArrayRef]).expect("batch");
+        let mut buffer = Vec::new();
+        {
+            let mut writer = ArrowWriter::try_new(&mut buffer, schema, None).expect("writer");
+            writer.write(&batch).expect("write");
+            writer.close().expect("close");
+        }
+        Bytes::from(buffer)
+    }
+
+    #[rstest]
+    fn matrix_provider_from_parquet() {
+        let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+        let bytes = write_parquet(array);
+        let provider = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "features")
+            .expect("parquet load");
+        assert_eq!(provider.len(), 2);
+        assert_eq!(provider.dimension(), 3);
+        assert_eq!(provider.data(), &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    }
+
+    #[rstest]
+    fn matrix_provider_parquet_missing_column() {
+        let array = build_array(&[[1.0, 2.0, 3.0]]);
+        let bytes = write_parquet(array);
+        let err = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "unknown")
+            .expect_err("missing column");
+        assert!(matches!(
+            err,
+            DenseMatrixProviderError::ColumnNotFound { column } if column == "unknown"
+        ));
+    }
+
+    #[rstest]
+    fn matrix_provider_parquet_wrong_type() {
+        let field = Field::new("features", DataType::Int32, false);
+        let schema = Arc::new(Schema::new(vec![field]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow_array::Int32Array::from(vec![1, 2, 3])) as ArrayRef],
+        )
+        .expect("batch");
+        let mut buffer = Vec::new();
+        {
+            let mut writer = ArrowWriter::try_new(&mut buffer, schema, None).expect("writer");
+            writer.write(&batch).expect("write");
+            writer.close().expect("close");
+        }
+        let bytes = Bytes::from(buffer);
+        let err = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "features")
+            .expect_err("wrong type");
+        assert!(matches!(
+            err,
+            DenseMatrixProviderError::InvalidColumnType { .. }
+        ));
     }
 }

--- a/docs/chutoro-design.md
+++ b/docs/chutoro-design.md
@@ -628,6 +628,17 @@ double-free if probed repeatedly.
    `HAS_DISTANCE_BATCH` is absent, the wrapper routes calls to the scalar
    `distance`. If `HAS_DEVICE_VIEW` is missing, host-managed buffers are used.
 
+#### 5.4. Walking skeleton dense ingestion
+
+The initial CPU-only skeleton now materialises Arrow and Parquet feature
+columns through `DenseMatrixProvider`. The provider normalises
+`FixedSizeList<Float32, D>` columns into a contiguous row-major `Vec<f32>` so
+the rest of the pipeline can reason about cache-friendly slices instead of
+nested Arrow arrays. Rows containing null lists or null scalar values are
+rejected with structured errors to keep distance computations deterministic.
+The Parquet path pushes a projection mask so only the requested feature column
+is scanned, helping future backends reuse the same ingestion contract.
+
 ### 6. Core Clustering Engine: A Multi-threaded CPU Implementation
 
 The default execution path for the clustering engine will be a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ ______________________________________________________________________
   §10.2)
 - [x] Implement `ChutoroBuilder` and `Chutoro::run<D: DataSource>`
   orchestration API. (See §10.1)
-- [ ] Implement `DenseMatrixProvider` that packs Parquet/Arrow
+- [x] Implement `DenseMatrixProvider` that packs Parquet/Arrow
   `FixedSizeList<Float32,D>` into a contiguous row‑major `Vec<f32>`; reject
   ragged/null rows. (See §5, §10.4)
 - [ ] Implement `TextProvider` (one UTF‑8 string per line) to exercise


### PR DESCRIPTION
## Summary
- add a `DenseMatrixProvider` that materialises Arrow `FixedSizeList<Float32, D>` columns into contiguous row-major buffers
- support loading the provider from Parquet readers with explicit validation errors and comprehensive rstest coverage
- document the dense ingestion contract in the design doc and mark the roadmap milestone as complete

## Testing
- make fmt
- make lint
- make test


------
https://chatgpt.com/codex/tasks/task_e_68d94f768cf48322aed4cef167c462b0