### PR TITLE
Clarify DenseSource lint justification

### DIFF
--- a/chutoro-providers/dense/src/source.rs
+++ b/chutoro-providers/dense/src/source.rs
@@ -32,7 +32,7 @@ impl DenseSource {
     pub fn new(name: impl Into<String>, data: Vec<Vec<f32>>) -> Self {
         #[expect(
             clippy::expect_used,
-            reason = "constructor panics on inconsistent row lengths"
+            reason = "constructor panics on empty data or inconsistent row lengths"
         )]
         Self::try_new(name, data)
             .expect("data must be non-empty with uniformly positive-dimension rows")


### PR DESCRIPTION
## Summary
- align the DenseSource expect attribute reason with the documented panic conditions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddaf84a5048322a3c5301faf55966b