### PR TITLE
Implement Levenshtein-backed text provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,8 @@ version = "0.1.0"
 dependencies = [
  "chutoro-core",
  "rstest",
+ "strsim",
+ "thiserror",
 ]
 
 [[package]]
@@ -1138,6 +1140,12 @@ name = "snap"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"

--- a/chutoro-providers/text/Cargo.toml
+++ b/chutoro-providers/text/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+[dependencies.strsim]
+version = "0.10"
+[dependencies.thiserror]
+version = "1.0"
 [dependencies.chutoro-core]
 version = "0.1.0"
 path = "../../chutoro-core"

--- a/chutoro-providers/text/tests/textsource.rs
+++ b/chutoro-providers/text/tests/textsource.rs
@@ -1,18 +1,53 @@
 #![expect(clippy::expect_used, reason = "tests require contextual panics")]
+use std::io::Cursor;
+
 use chutoro_core::{DataSource, DataSourceError};
-use chutoro_providers_text::TextSource;
+use chutoro_providers_text::{TextProvider, TextProviderError};
 use rstest::rstest;
 
 #[rstest]
-fn distance_returns_abs_char_count_diff() {
-    let ds = TextSource::new("demo", vec!["a".into(), "bbb".into()]);
-    let dist = ds.distance(0, 1).expect("distance must succeed");
-    assert_eq!(dist, 2.0);
+#[case("kitten", "sitting", 3.0)]
+#[case("gumbo", "gambol", 2.0)]
+#[case("", "", 0.0)]
+#[case("naïve", "naive", 1.0)]
+fn distance_returns_levenshtein(#[case] left: &str, #[case] right: &str, #[case] expected: f32) {
+    let provider = TextProvider::new("demo", vec![left.to_owned(), right.to_owned()])
+        .expect("provider must build");
+    let dist = provider.distance(0, 1).expect("distance must succeed");
+    assert_eq!(dist, expected);
+    let reverse = provider.distance(1, 0).expect("distance must succeed");
+    assert_eq!(reverse, expected);
 }
 
 #[rstest]
 fn distance_bounds_check() {
-    let ds = TextSource::new("demo", vec!["a".into()]);
-    let err = ds.distance(0, 1).expect_err("distance must check bounds");
+    let provider = TextProvider::new("demo", vec!["a".into()]).expect("provider must build");
+    let err = provider
+        .distance(0, 1)
+        .expect_err("distance must check bounds");
     assert!(matches!(err, DataSourceError::OutOfBounds { index: 1 }));
+}
+
+#[rstest]
+#[case("alpha\nbeta\n", &["alpha", "beta"])]
+#[case("carriage\r\nreturn\r\n", &["carriage", "return"])]
+#[case("lonely", &["lonely"])]
+fn try_from_reader_trims_newlines(#[case] raw: &str, #[case] expected: &[&str]) {
+    let cursor = Cursor::new(raw);
+    let provider = TextProvider::try_from_reader("demo", cursor).expect("provider must build");
+    let items: Vec<&str> = provider.lines().iter().map(String::as_str).collect();
+    assert_eq!(items, expected);
+}
+
+#[rstest]
+fn try_from_reader_empty_input() {
+    let err =
+        TextProvider::try_from_reader("demo", Cursor::new("")).expect_err("empty input must fail");
+    assert!(matches!(err, TextProviderError::EmptyInput));
+}
+
+#[rstest]
+fn new_rejects_empty_collection() {
+    let err = TextProvider::new("demo", Vec::new()).expect_err("empty input must fail");
+    assert!(matches!(err, TextProviderError::EmptyInput));
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ ______________________________________________________________________
 - [x] Implement `DenseMatrixProvider` that packs Parquet/Arrow
   `FixedSizeList<Float32,D>` into a contiguous row‑major `Vec<f32>`; reject
   ragged/null rows. (See §5, §10.4)
-- [ ] Implement `TextProvider` (one UTF‑8 string per line) to exercise
+- [x] Implement `TextProvider` (one UTF‑8 string per line) to exercise
   non‑metric distances (e.g., Levenshtein). (See §1.3)
 - [ ] Add `cosine` and `euclidean` distance implementations in `chutoro-core`
   with optional precomputed norms for cosine. (See §3.1)


### PR DESCRIPTION
## Summary
- add a `TextProvider` that ingests UTF-8 lines, computes Levenshtein distances via `strsim`, and exposes the stored strings
- provide reader-based construction with explicit error types and rstest coverage for happy and unhappy paths
- document the walking-skeleton text ingestion plan and mark the roadmap entry complete

## Testing
- make fmt
- make lint
- make test
- make check-fmt

------
https://chatgpt.com/codex/tasks/task_e_68e05a1609e88322a18af7a53d8aaac8