### PR TITLE
Extract logging conflict diagnostic helper

### DIFF
--- a/chutoro-cli/src/logging.rs
+++ b/chutoro-cli/src/logging.rs
@@ -125,9 +125,9 @@ fn install_subscriber() -> Result<(), LoggingError> {
 /// Emit a pre-initialisation diagnostic to stderr when structured logging
 /// initialisation collides with an existing subscriber.
 ///
-/// Clippy::print_stderr is a single lint we deny workspace-wide; suppress it
-/// narrowly for this pre-init diagnostic call because structured logging is not
-/// yet available.
+/// Clippy's `print_stderr` lint is denied workspace-wide; suppress it narrowly
+/// for this pre-init diagnostic because structured logging is not yet available
+/// and stderr is the only output channel.
 ///
 /// # Examples
 /// ```ignore


### PR DESCRIPTION
## Summary
- extract the stderr logging conflict diagnostic into a helper so it can be annotated consistently
- reuse the helper when subscriber installation fails before marking initialization complete

## Testing
- make check-fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68f0bb3b61d08322b78b6e1e9e3aa166

## Summary by Sourcery

Extract stderr logging conflict diagnostic into a dedicated helper and reuse it for subscriber installation failures

Enhancements:
- Introduce `report_logging_conflict` helper to centralize stderr diagnostics for logging conflicts
- Replace inline stderr message with the new helper in the `init_logging` error path