### PR TITLE
Refactor: Decompose search_property.rs into modules

### DIFF
--- a/chutoro-core/src/hnsw/tests/property/mod.rs
+++ b/chutoro-core/src/hnsw/tests/property/mod.rs
@@ -2,6 +2,7 @@
 
 pub(super) mod datasets;
 pub(super) mod mutation_property;
+pub(super) mod search_config;
 pub(super) mod search_property;
 pub(super) mod strategies;
 pub(super) mod support;

--- a/chutoro-core/src/hnsw/tests/property/search_config.rs
+++ b/chutoro-core/src/hnsw/tests/property/search_config.rs
@@ -1,0 +1,130 @@
+//! Configuration and parsing for the HNSW search-correctness property.
+//!
+//! Reads environment overrides for the minimum recall threshold and maximum
+//! fixture length used by the property-based search tests.
+
+use std::env;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum RecallThresholdError {
+    ParseFloat,
+    OutOfRange { value: f32 },
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SearchPropertyConfig {
+    min_recall: f32,
+    max_fixture_len: usize,
+}
+
+impl SearchPropertyConfig {
+    pub(super) const ENV_KEY: &'static str = "CHUTORO_HNSW_PBT_MIN_RECALL";
+    pub(super) const MAX_FIXTURE_LEN_ENV_KEY: &'static str = "CHUTORO_HNSW_PBT_MAX_FIXTURE_LEN";
+    pub(super) const DEFAULT_MIN_RECALL: f32 = 0.50;
+    pub(super) const DEFAULT_MAX_FIXTURE_LEN: usize = 32;
+
+    pub(super) fn load() -> Self {
+        let min_recall = Self::read_env_or_default(
+            Self::ENV_KEY,
+            Self::DEFAULT_MIN_RECALL,
+            Self::parse_min_recall,
+        );
+        let max_fixture_len = Self::read_env_or_default(
+            Self::MAX_FIXTURE_LEN_ENV_KEY,
+            Self::DEFAULT_MAX_FIXTURE_LEN,
+            Self::parse_max_fixture_len,
+        );
+
+        Self {
+            min_recall,
+            max_fixture_len,
+        }
+    }
+
+    pub(super) fn min_recall(&self) -> f32 {
+        self.min_recall
+    }
+
+    pub(super) fn max_fixture_len(&self) -> usize {
+        self.max_fixture_len
+    }
+
+    fn read_env_or_default<T, F>(key: &'static str, default: T, parser: F) -> T
+    where
+        T: Copy,
+        F: Fn(&str) -> Result<T, String>,
+    {
+        match env::var(key) {
+            Ok(raw) => match parser(&raw) {
+                Ok(value) => value,
+                Err(reason) => {
+                    tracing::warn!(
+                        env = key,
+                        raw = %raw,
+                        reason = %reason,
+                        "invalid config override, falling back to default",
+                    );
+                    default
+                }
+            },
+            Err(_) => default,
+        }
+    }
+
+    fn parse_min_recall(raw: &str) -> Result<f32, String> {
+        parse_recall_threshold(raw).map_err(|err| format!("{err:?}"))
+    }
+
+    fn parse_max_fixture_len(raw: &str) -> Result<usize, String> {
+        let trimmed = raw.trim();
+        let parsed = trimmed
+            .parse::<usize>()
+            .map_err(|err| format!("parse error: {err}"))?;
+        if parsed < 2 {
+            return Err("value must be >= 2".to_string());
+        }
+        Ok(parsed)
+    }
+}
+
+pub(super) fn parse_recall_threshold(raw: &str) -> Result<f32, RecallThresholdError> {
+    let trimmed = raw.trim();
+    let parsed = trimmed
+        .parse::<f32>()
+        .map_err(|_| RecallThresholdError::ParseFloat)?;
+    if parsed <= 0.0 || parsed > 1.0 {
+        return Err(RecallThresholdError::OutOfRange { value: parsed });
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("0.5", 0.5)]
+    #[case("1.0", 1.0)]
+    #[case("0.01", 0.01)]
+    fn parse_recall_threshold_accepts_valid_values(#[case] input: &str, #[case] expected: f32) {
+        let parsed = parse_recall_threshold(input).expect("value should parse");
+        assert!(
+            (parsed - expected).abs() < f32::EPSILON,
+            "parsed {parsed} vs {expected}"
+        );
+    }
+
+    #[rstest]
+    #[case("0.0", RecallThresholdError::OutOfRange { value: 0.0 })]
+    #[case("-0.1", RecallThresholdError::OutOfRange { value: -0.1 })]
+    #[case("1.0001", RecallThresholdError::OutOfRange { value: 1.0001 })]
+    #[case("abc", RecallThresholdError::ParseFloat)]
+    fn parse_recall_threshold_rejects_invalid_values(
+        #[case] input: &str,
+        #[case] expected: RecallThresholdError,
+    ) {
+        let err = parse_recall_threshold(input).expect_err("value should fail");
+        assert_eq!(err, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- Decomposed search-property tests by extracting configuration parsing and recall threshold logic into a new module.
- Introduced `search_config` module to encapsulate env-driven configuration and validation.
- Updated tests to reuse the new configuration module.
- No behavioral changes to the search property logic; this is a structural refactor to improve maintainability.

## Changes
### New
- New module: chutoro-core/src/hnsw/tests/property/search_config.rs
  - Defines `SearchPropertyConfig` with environment overrides and defaults:
    - ENV keys: `CHUTORO_HNSW_PBT_MIN_RECALL`, `CHUTORO_HNSW_PBT_MAX_FIXTURE_LEN`
    - Defaults: min recalls = 0.50, max fixture length = 32
  - Provides environment loading with parsing/validation and warning logs for invalid overrides
  - Exposes `parse_recall_threshold` and `RecallThresholdError` for reuse
  - Includes unit tests for recall threshold parsing (valid and invalid cases)

### Updated
- chutoro-core/src/hnsw/tests/property/mod.rs
  - Expose new module: `pub(super) mod search_config;`
- chutoro-core/src/hnsw/tests/property/search_property.rs
  - Removed in-file recall threshold and config definitions
  - Now imports `SearchPropertyConfig` from the new `search_config` module
  - Maintains existing test logic for search correctness while delegating config concerns to the new module
  - Adjusted imports to reflect the new structure (e.g., `use super::search_config::SearchPropertyConfig;`)

## Test Plan
- Run full test suite: `cargo test` for chutoro-core
- Validate environment overrides:
  - Valid values are applied (e.g., `

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/729fc02f-e704-449a-8315-6443bad12d1b

## Summary by Sourcery

Extract HNSW search property test configuration and recall threshold parsing into a dedicated module to improve structure and reuse.

Enhancements:
- Introduce a new search_config module encapsulating env-driven configuration and recall threshold parsing for HNSW search property tests.
- Refactor search_property tests to depend on the shared configuration module instead of inlined config logic.

Tests:
- Add unit tests for recall threshold parsing in the new search_config module.