### PR TITLE
Integrate inline reciprocity enforcement with tests

### DIFF
--- a/docs/chutoro-design.md
+++ b/docs/chutoro-design.md
@@ -989,6 +989,19 @@ original graph and surfaces a `GraphInvariantViolation`. This fail-fast path
 keeps mutation plans deterministic without exposing delete semantics in the
 production API.
 
+#### 6.8. Inline reciprocity enforcement
+
+_Implementation update (2025-12-04)._ The insertion executor now enforces
+bidirectional links while applying trimmed neighbour lists instead of running a
+post-pass scan across touched nodes. `EdgeReconciler` still inserts reverse
+edges (or drops the forward edge when capacity or level gaps block
+reciprocity), and `ReciprocityWorkspace` rewrites trimmed updates when trimming
+evicts the new node. A new debug-only `ReciprocityAuditor` asserts that every
+touched node keeps a reciprocal back-link and stays within the per-level degree
+limit; production builds skip the scan entirely. The fallback healing path
+remains unchanged, so trimmed evictions still replace the weakest candidate
+with the new node to guarantee at least one reciprocal link per level.
+
 ## Part III: GPU Acceleration Strategy
 
 To achieve the highest possible performance on large datasets, the design

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,8 +97,8 @@ ______________________________________________________________________
   - [x] Add a regression test where trimming evicts the new node from an
         existing neighbour, asserting the post-commit reciprocity pass either
         adds the reverse edge or removes the forward edge.
-  - [ ] Integrate reciprocity enforcement into the insertion executor to avoid
-    the post-pass scan once correctness is validated.
+  - [x] Integrate reciprocity enforcement into the insertion executor to avoid
+        the post-pass scan once correctness is validated.
 - [ ] Add HNSW insertion idempotency property: repeated duplicate insertions
   leave graph state unchanged. (See property-testing-design §2.3.3)
 - [ ] Implement composite graph strategies (random, scale-free, lattice,


### PR DESCRIPTION
## Summary
- Integrates bidirectional reciprocity enforcement directly into the insertion executor (inline) and adds a test-time auditor to validate invariants.
- Production builds skip the audit path via cfg(test, debug_assertions) to avoid runtime overhead.
- Updates tests and documentation to reflect the inline enforcement approach.

## Changes
- chutoro-core/src/hnsw/insert/executor.rs
  - Add inline reciprocity enforcement guarded by #[cfg(any(test, debug_assertions))] using ReciprocityAuditor.
  - Retain non-auditing path for release builds with a no-op to avoid overhead.
- chutoro-core/src/hnsw/insert/executor/tests.rs
  - Rework tests to exercise the inline reciprocity path.
  - Introduce a new test case commit_inlines_reciprocity with deterministic setup and assertions about bidirectional edges after commit.
  - Adjust expectations to reflect inline enforcement rather than a separate post-pass step.
- chutoro-core/src/hnsw/insert/reciprocity.rs
  - Introduce ReciprocityAuditor (debug/test only) to validate touched nodes and their neighbours at each level.
  - Implement AuditContext, assert_reciprocity_for_touched, assert_origin_state, and assert_target_state helpers.
  - Ensure production builds do not pull in the auditor paths.
- docs/chutoro-design.md
  - Document the new inline reciprocity enforcement (section 6.8).
  - Explain how the inline path enforces bidirectional links during trimming and how the auditor asserts invariants in debug/test builds.
- docs/roadmap.md
  - Reflect that integration of reciprocity enforcement into the insertion executor is completed (previously a todo).

## Why this change
- Shifts reciprocity enforcement from a post-commit scan to an inline enforcement step, reducing reliance on later reconciliation and improving determinism of the mutation plan.
- Keeps a lightweight, test-only auditor to validate correctness during development without impacting production performance.

## Testing plan
- Run cargo test with test/debug assertions enabled to exercise the ReciprocityAuditor path.
- Validate that after commit, expected bidirectional edges exist and that non-reciprocal edges are removed or adjusted as appropriate according to the tests.
- Ensure release/production builds compile without the auditor-related code paths.

## Impact and compatibility
- No API changes for production users; the auditor is compiled only for tests/debug builds.
- The inline enforcement path should reduce reliance on post-pass reciprocity checks while preserving the same final graph invariants.

## Notes
- The changes align with the updated design docs and roadmap, confirming the inline reciprocity enforcement approach is now implemented and tested.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3bbb3ec5-6397-4110-8cac-83eda7188473

## Summary by Sourcery

Inline reciprocity enforcement into the HNSW insertion executor with a debug-only auditor and update tests and docs accordingly.

Enhancements:
- Add a debug/test-only ReciprocityAuditor to validate bidirectional edges and degree limits after insertion commits without affecting release builds.
- Wire reciprocity auditing into the insertion executor to check touched nodes inline while keeping the production path no-op for performance.
- Extend design documentation to describe inline reciprocity enforcement and mark the roadmap item for executor integration as completed.

Tests:
- Replace the standalone reciprocity enforcement test with a new commit_inlines_reciprocity scenario that exercises inline enforcement, trimming behavior, and bidirectional edge invariants.