### PR TITLE
Align roadmap with the roadmap grammar

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,6 +5,67 @@ rather than external sources._
 
 ______________________________________________________________________
 
+## Benchmark dataset suite
+
+| Scale        | Dataset                                                                                                        | Size / Dim.                                | Labels / "clusters"                    | Why it's useful                                                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------------------- | -----------------------------------------: | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Toy-Small    | [`make_blobs`](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_blobs.html) (synthetic) | configurable                               | exact cluster IDs                      | Sanity-check end-to-end behaviour; control separation, anisotropy, imbalance, and noise.                                                   |
+| Small        | [MNIST digits](http://yann.lecun.com/exdb/mnist/)                                                              | 70k × 784                                  | 10 classes                             | Easy, well-behaved baseline for Euclidean space; also available prepackaged for ANN-Benchmarks.                                            |
+| Small        | [Fashion-MNIST](https://github.com/zalandoresearch/fashion-mnist)                                              | 70k × 784                                  | 10 classes                             | Slightly harder clusters than MNIST; drop-in replacement; HDF5 splits exist in ANN-Benchmarks.                                             |
+| Small-Medium | [CIFAR-10 / CIFAR-100](https://www.cs.toronto.edu/~kriz/cifar.html)                                            | 60k × 3×32×32                              | 10 / 100 classes                       | Labels enable testing both "coarse" and "fine" cluster granularity; embedding via a fixed CNN yields vectors.                              |
+| Medium       | [20 Newsgroups](https://scikit-learn.org/stable/datasets/real_world.html#newsgroups-dataset)                   | 18,846 docs                                | 20 topics                              | Text with clear topic labels; create vectors (e.g., TF-IDF, SBERT) then test cluster recovery.                                             |
+| Medium-Large | [RCV1-v2](https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_rcv1.html)                  | 804,414 docs, 103 topics                   | multilabel topics                      | Large, messy, real text; multilabel enables probing overlapping clusters; scikit-learn fetcher provides canonical split.                   |
+| Medium       | [SNAP com-Amazon](https://snap.stanford.edu/data/)                                                             | 334,863 nodes                              | product categories = communities       | Real graph with ground-truth communities for community/cluster evaluation after k-NN graph build.                                          |
+| Medium       | [SNAP com-DBLP](https://snap.stanford.edu/data/)                                                               | 317,080 nodes                              | venue-based communities                | Overlapping scientific communities; good stress for cluster quality on graph structures.                                                   |
+| Medium (bio) | [PBMC 68k (10x Genomics)](https://support.10xgenomics.com/single-cell-gene-expression/datasets)                | ~68k cells, ≫10k genes → 50d (PCA)         | cell-type labels                       | Classic scRNA-seq clustering benchmark with annotated cell types; strong test for high-dimensional distances.                              |
+| Large (ANN)  | [GloVe word vectors](https://nlp.stanford.edu/projects/glove/)                                                 | 1.18M × {25,50,100,200}                    | none (but lexical categories possible) | Covers angular distance regimes; turnkey HDF5 in ANN-Benchmarks.                                                                           |
+| Large (ANN)  | [SIFT1M](https://github.com/erikbern/ann-benchmarks)                                                           | 1,000,000 × 128                            | nn ground truth (no classes)           | De-facto Euclidean Approximate Nearest Neighbour (ANN) baseline with exact k-NN ground truth; great for graph/MST quality via k-NN recall. |
+| Large (ANN)  | [GIST1M](https://github.com/erikbern/ann-benchmarks)                                                           | 1,000,000 × 960                            | nn ground truth                        | Very high-dimensional Euclidean stress test; in ANN-Benchmarks.                                                                            |
+| XL-Billion   | [DEEP1B / BigANN](https://github.com/erikbern/ann-benchmarks)                                                  | up to 1B × 96 (Deep1B) / 128 (SIFT BigANN) | nn ground truth                        | For scale limits, memory pressure, sharding; official subsets (1M/10M/100M) and GT available.                                              |
+
+_Table 1: Benchmark datasets by scale, with dimensions, labels, and rationale._
+
+Provenance notes:
+
+- `make_blobs`: BSD-3 via scikit-learn.
+- MNIST digits: Yann LeCun; permissive distribution.
+- Fashion-MNIST: MIT licence from Zalando.
+- CIFAR-10/100: MIT licence; provided by Krizhevsky et al.
+- 20 Newsgroups: by Ken Lang; available via scikit-learn fetcher.
+- RCV1-v2: Reuters licence; fetched with scikit-learn.
+- SNAP com-Amazon: Stanford SNAP dataset under CC BY-SA.
+- SNAP com-DBLP: Stanford SNAP dataset under CC BY-SA.
+- PBMC 68k: 10x Genomics, CC BY 4.0.
+- GloVe word vectors: Stanford NLP, public domain.
+- SIFT1M: ANN-Benchmarks HDF5 package.
+- GIST1M: ANN-Benchmarks HDF5 package.
+- DEEP1B/BigANN: ANN-Benchmarks HDF5 package.
+
+### How to use them (minimal ceremony)
+
+- **With labels (MNIST/Fashion-MNIST/CIFAR/20NG/RCV1/SNAP/PBMC):**
+  build k-NN/HNSW, run the MST/clusterer, and score with NMI/ARI vs. labels;
+  also report k-NN recall@k vs. exact neighbours to measure graph fidelity.
+  Recall@k is |P ∩ G_k|/k where G_k is the exact neighbour list (including
+  ties) supplied with the dataset.
+- **Without labels (SIFT/GIST/GloVe/DEEP1B):** rely on provided
+  **exact neighbour ground truth** for recall@{1,10,100} and report graph
+  metrics (conductance, connected-component purity) as proxies for cluster
+  "shape." Conductance = cut(S, V−S)/min(vol(S), vol(V−S)) and
+  connected-component purity is the dominant label count divided by the
+  component size. ANN-Benchmarks HDF5 packs standardize splits and ground truth.
+
+### Practical picks by "benchmark tier"
+
+- **Smoke tests (minutes):** `make_blobs` (varied separation),
+  MNIST/Fashion-MNIST.
+- **Serious CPU micro/macro (hours):** 20 Newsgroups, RCV1-v2,
+  SNAP com-Amazon/com-DBLP, SIFT1M.
+- **Scale and memory (days):** GIST1M, GloVe-200d, DEEP10M/100M, and
+  DEEP1B/BigANN for the most demanding scale.
+
+______________________________________________________________________
+
 ## 0. Walking skeleton (CPU-only, no dynamic plugins)
 
 ### 0.1. Workspace and core API
@@ -1140,80 +1201,3 @@ ground-truth-labelled documents; the streaming benchmark harness measures
 quality, churn, latency, stability, and drift detection; acceptance criteria
 are met on the `smoke` profile; CI publishes and compares metric summaries; the
 corpus manifest and drift breakpoints are deterministic from seed.
-
-______________________________________________________________________
-
-## Benchmark dataset suite
-
-| Scale        | Dataset                      | Size / Dim.                                 | Labels / "clusters"                    | Why it's useful                                                                                                                            |
-| ------------ | ---------------------------- | ------------------------------------------: | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| Toy-Small    | `make_blobs` (synthetic)[^1] | configurable                                | exact cluster IDs                      | Sanity-check end-to-end behaviour; control separation, anisotropy, imbalance, and noise.                                                   |
-| Small        | MNIST digits[^2]             | 70k × 784                                   | 10 classes                             | Easy, well-behaved baseline for Euclidean space; also available prepackaged for ANN-Benchmarks.                                            |
-| Small        | Fashion-MNIST[^3]            | 70k × 784                                   | 10 classes                             | Slightly harder clusters than MNIST; drop-in replacement; HDF5 splits exist in ANN-Benchmarks.                                             |
-| Small-Medium | CIFAR-10 / CIFAR-100[^4]     | 60k × 3×32×32                               | 10 / 100 classes                       | Labels enable testing both "coarse" and "fine" cluster granularity; embedding via a fixed CNN yields vectors.                              |
-| Medium       | 20 Newsgroups[^5]            | 18,846 docs                                 | 20 topics                              | Text with clear topic labels; create vectors (e.g., TF-IDF, SBERT) then test cluster recovery.                                             |
-| Medium-Large | RCV1-v2[^6]                  | 804,414 docs, 103 topics                    | multilabel topics                      | Large, messy, real text; multilabel enables probing overlapping clusters; scikit-learn fetcher provides canonical split.                   |
-| Medium       | SNAP com-Amazon[^7]          | 334,863 nodes                               | product categories = communities       | Real graph with ground-truth communities for community/cluster evaluation after k-NN graph build.                                          |
-| Medium       | SNAP com-DBLP[^7]            | 317,080 nodes                               | venue-based communities                | Overlapping scientific communities; good stress for cluster quality on graph structures.                                                   |
-| Medium (bio) | PBMC 68k (10x Genomics)[^8]  | ~68k cells, ≫10k genes → 50d (PCA)          | cell-type labels                       | Classic scRNA-seq clustering benchmark with annotated cell types; strong test for high-dimensional distances.                              |
-| Large (ANN)  | GloVe word vectors[^9]       | 1.18M × {25,50,100,200}                     | none (but lexical categories possible) | Covers angular distance regimes; turnkey HDF5 in ANN-Benchmarks.                                                                           |
-| Large (ANN)  | SIFT1M[^10]                  | 1,000,000 × 128                             | nn ground truth (no classes)           | De-facto Euclidean Approximate Nearest Neighbour (ANN) baseline with exact k-NN ground truth; great for graph/MST quality via k-NN recall. |
-| Large (ANN)  | GIST1M[^10]                  | 1,000,000 × 960                             | nn ground truth                        | Very high-dimensional Euclidean stress test; in ANN-Benchmarks.                                                                            |
-| XL-Billion   | DEEP1B / BigANN[^10]         | up to 1B × 96 (Deep1B) / 128 (SIFT BigANN)  | nn ground truth                        | For scale limits, memory pressure, sharding; official subsets (1M/10M/100M) and GT available.                                              |
-
-_Table 1: Benchmark datasets by scale, with dimensions, labels, and rationale._
-
-Provenance notes:
-
-- `make_blobs`: BSD-3 via scikit-learn.[^1]
-- MNIST digits: Yann LeCun; permissive distribution.[^2]
-- Fashion-MNIST: MIT licence from Zalando.[^3]
-- CIFAR-10/100: MIT licence; provided by Krizhevsky et al.[^4]
-- 20 Newsgroups: by Ken Lang; available via scikit-learn fetcher.[^5]
-- RCV1-v2: Reuters licence; fetched with scikit-learn.[^6]
-- SNAP com-Amazon: Stanford SNAP dataset under CC BY-SA.[^7]
-- SNAP com-DBLP: Stanford SNAP dataset under CC BY-SA.[^7]
-- PBMC 68k: 10x Genomics, CC BY 4.0.[^8]
-- GloVe word vectors: Stanford NLP, public domain.[^9]
-- SIFT1M: ANN-Benchmarks HDF5 package.[^10]
-- GIST1M: ANN-Benchmarks HDF5 package.[^10]
-- DEEP1B/BigANN: ANN-Benchmarks HDF5 package.[^10]
-
-### How to use them (minimal ceremony)
-
-- **With labels (MNIST/Fashion-MNIST/CIFAR/20NG/RCV1/SNAP/PBMC):**
-  build k-NN/HNSW, run the MST/clusterer, and score with NMI/ARI vs. labels;
-  also report k-NN recall@k vs. exact neighbours to measure graph fidelity.
-  Recall@k is |P ∩ G_k|/k where G_k is the exact neighbour list (including
-  ties) supplied with the dataset.
-- **Without labels (SIFT/GIST/GloVe/DEEP1B):** rely on provided
-  **exact neighbour ground truth** for recall@{1,10,100} and report graph
-  metrics (conductance, connected-component purity) as proxies for cluster
-  "shape." Conductance = cut(S, V−S)/min(vol(S), vol(V−S)) and
-  connected-component purity is the dominant label count divided by the
-  component size. ANN-Benchmarks HDF5 packs standardize splits and ground truth.
-
-### Practical picks by "benchmark tier"
-
-- **Smoke tests (minutes):** `make_blobs` (varied separation),
-  MNIST/Fashion-MNIST.
-- **Serious CPU micro/macro (hours):** 20 Newsgroups, RCV1-v2,
-  SNAP com-Amazon/com-DBLP, SIFT1M.
-- **Scale and memory (days):** GIST1M, GloVe-200d, DEEP10M/100M, and
-  DEEP1B/BigANN for the most demanding scale.
-
-[^1]: scikit-learn — make_blobs —
-  <https://scikit-learn.org/stable/modules/generated/sklearn.datasets.make_blobs.html>
-[^2]: MNIST database — <http://yann.lecun.com/exdb/mnist/>
-[^3]: Fashion-MNIST — <https://github.com/zalandoresearch/fashion-mnist>
-[^4]: CIFAR-10/100 — <https://www.cs.toronto.edu/~kriz/cifar.html>
-[^5]: 20 Newsgroups —
-  <https://scikit-learn.org/stable/datasets/real_world.html#newsgroups-dataset>
-[^6]: RCV1-v2 —
-  <https://scikit-learn.org/stable/modules/generated/sklearn.datasets.fetch_rcv1.html>
-[^7]: SNAP datasets — <https://snap.stanford.edu/data/>
-[^8]: PBMC 68k —
-  <https://support.10xgenomics.com/single-cell-gene-expression/datasets>
-[^9]: GloVe vectors — <https://nlp.stanford.edu/projects/glove/>
-[^10]: ANN-Benchmarks datasets —
-  <https://github.com/erikbern/ann-benchmarks>


### PR DESCRIPTION
## Summary

This branch aligns the roadmap with the mapsplice roadmap grammar. The
trailing `## Benchmark dataset suite` section (dataset table, provenance
notes, and two unnumbered level-3 subsections) sat after the numbered phases,
which the grammar rejects ("unsupported non-roadmap heading inside the roadmap
body"). It also used footnote references (`[^1]`–`[^10]`), which the grammar
rejects anywhere in the document. The section moves, headings and wording
intact, into the preamble before the first phase; the footnotes become inline
links on the dataset names in the table; the redundant footnote markers in the
provenance notes are dropped and the footnote definition block removed. No
phases, steps, or tasks are reordered, renumbered, or reworded, and no
checkbox states change.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/chutoro/blob/docs/roadmap-syntax/docs/roadmap.md) to see the benchmark dataset suite now in the preamble, with each dataset name in the table carrying the inline link that its footnote previously supplied; the phase body from `## 0.` onwards is otherwise untouched.

## Validation

- `mapsplice append docs/roadmap.md <dummy-phase>`: exit 0 (grammar-clean)
- `bunx markdownlint-cli2 docs/roadmap.md`: 0 errors

## Notes

- Demoting the three headings to bold paragraphs in place was rejected
  because it trips markdownlint MD036 (emphasis used instead of a heading);
  the section is reference material rather than task-like content, so
  converting it to a numbered phase was also inappropriate.
- The provenance-note footnote markers duplicated the table's sources, so
  they were removed rather than duplicated as a second set of inline links;
  every footnote URL survives exactly once, on the dataset name in the table.
- Table columns were realigned (whitespace only) after the link substitution.
- Anomaly, deliberately not fixed: the roadmap numbers its first phase
  `## 0.`, which the grammar's phase rule disallows (phases must be positive
  integers), yet the mechanical checker accepts the document by treating the
  zero-numbered phase as preamble. Shifting to 1-based numbering would
  renumber every phase, step, task, and cross-reference in the document —
  exactly the renumbering churn this exercise forbids — so it is flagged
  here for a human decision instead.
