### PR TITLE
Add scheduled mutation testing via the shared workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
             !**/dist/**
       - name: Lint
         run: make lint
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          python-version: '3.13'
+          enable-cache: true
+      - name: Workflow contract tests
+        run: make test-workflow-contracts
       - name: Test and Measure Coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
         with:

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -1,0 +1,43 @@
+name: Mutation testing
+
+# Thin caller of the shared mutation-testing reusable workflow; caller
+# guide: leynos/shared-actions docs/mutation-cargo-workflow.md.
+# Scheduled runs mutate only files changed within the detection window;
+# manual dispatch runs mutate everything, fanned out across shards. To
+# test a branch, select it in the Actions "Run workflow" control.
+
+on:
+  schedule:
+    - cron: "35 4 * * *" # Daily, 04:35 UTC
+  workflow_dispatch:
+
+# Default the token to no scopes; the job opts in explicitly.
+permissions: {}
+
+# Serialize runs per ref: a dispatch during a scheduled run (or vice
+# versa) queues rather than racing. Runs are informational, so queued
+# runs wait instead of cancelling.
+concurrency:
+  group: mutation-testing-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mutation:
+    permissions:
+      contents: read
+      id-token: write # OIDC workflow-source resolution
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    with:
+      # Workspace crates live in top-level directories, not a root
+      # src/. chutoro-test-support (test scaffolding) and the root
+      # verus/ proof files are deliberately left outside: their
+      # survivors would be noise.
+      paths: "chutoro-core/,chutoro-cli/,chutoro-providers/,chutoro-benches/"
+      # Kani proof modules only compile under `cargo kani`
+      # (nightly-kani.yml), the unconditional insert test helpers are
+      # scaffolding, and the session_api_without_cpu fixture crate sits
+      # outside the workspace; mutants in any of them are noise.
+      exclude-globs: "chutoro-core/src/hnsw/kani_proofs/**,chutoro-providers/dense/src/simd/kani_proofs.rs,chutoro-core/src/hnsw/insert/test_helpers.rs,chutoro-core/tests/fixtures/**"
+      # Match the CI baseline (`make test` runs --all-features) so
+      # feature-gated tests run against mutants.
+      extra-args: "--all-features"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage.xml
 .memdb/
 .verus/
 *.swp
+__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help all clean test build release typecheck lint fmt check-fmt markdownlint nixie kani kani-full verus bench
+.PHONY: help all clean test build release typecheck lint fmt check-fmt markdownlint nixie kani kani-full verus bench test-workflow-contracts
 
 export PATH := $(HOME)/.cargo/bin:$(HOME)/.bun/bin:$(PATH)
 
@@ -66,6 +66,9 @@ verus: ## Run Verus proofs for edge harvest primitives
 
 bench: ## Run Criterion benchmarks
 	$(CARGO) bench -p chutoro-benches
+
+test-workflow-contracts: ## Validate the mutation-testing caller contract
+	uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -1,0 +1,150 @@
+"""Contract tests for the mutation-testing caller workflow.
+
+The executable logic lives in the ``leynos/shared-actions`` reusable
+workflow, which carries its own unit and integration tests; chutoro's
+caller is declarative configuration. These tests parse the caller with
+PyYAML and pin the contract it must uphold, so drift (repointing the pin
+at a branch, widening permissions, or losing the paths, exclusions, and
+feature configuration) fails CI on the pull request rather than
+surfacing in a scheduled or manual run.
+
+Run via ``make test-workflow-contracts``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
+)
+
+#: The commit SHA of the shared workflow pin (the merge commit of
+#: leynos/shared-actions PR #319). Bump the workflow and this test
+#: together.
+PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+
+EXPECTED_USES = (
+    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+)
+
+#: The exact caller configuration: workspace crate paths (the repo has
+#: no root src/; chutoro-test-support and verus/ stay outside), the
+#: Kani-proof and scaffolding exclusions, and the --all-features
+#: baseline mirrored from `make test`.
+EXPECTED_WITH = {
+    "paths": "chutoro-core/,chutoro-cli/,chutoro-providers/,chutoro-benches/",
+    "exclude-globs": (
+        "chutoro-core/src/hnsw/kani_proofs/**,"
+        "chutoro-providers/dense/src/simd/kani_proofs.rs,"
+        "chutoro-core/src/hnsw/insert/test_helpers.rs,"
+        "chutoro-core/tests/fixtures/**"
+    ),
+    "extra-args": "--all-features",
+}
+
+
+def _load() -> dict[str, object]:
+    """Parse the workflow file."""
+    return yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the ``on:`` mapping (PyYAML parses the bare key as True)."""
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict), "the workflow must declare an on: mapping"
+    return triggers
+
+
+def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
+    """Return the single calling job."""
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "the workflow must declare a jobs mapping"
+    assert jobs, "the workflow must declare at least one job"
+    assert list(jobs) == ["mutation"], (
+        f"expected a single job named 'mutation', found {sorted(jobs)}"
+    )
+    return jobs["mutation"]
+
+
+def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
+    """The job must call the shared workflow at the exact documented SHA."""
+    uses = _mutation_job(_load()).get("uses")
+    assert uses is not None, "jobs.mutation.uses is missing"
+    path, _, ref = uses.partition("@")
+    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
+        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
+    )
+    assert len(ref) == 40, (
+        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert all(c in "0123456789abcdef" for c in ref), (
+        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
+        f"not a branch or tag: {ref!r}"
+    )
+    assert uses == EXPECTED_USES, (
+        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
+        "bump the test together with the workflow"
+    )
+
+
+def test_job_permissions_are_exactly_least_privilege() -> None:
+    """The job grants contents: read and id-token: write, nothing broader."""
+    permissions = _mutation_job(_load()).get("permissions")
+    assert permissions == {"contents": "read", "id-token": "write"}, (
+        "jobs.mutation.permissions must be exactly "
+        f"{{'contents': 'read', 'id-token': 'write'}}, got {permissions!r}"
+    )
+
+
+def test_workflow_default_permissions_are_empty() -> None:
+    """The workflow-level default token scope is empty."""
+    workflow = _load()
+    assert workflow.get("permissions") == {}, (
+        f"top-level permissions must be an empty mapping, got "
+        f"{workflow.get('permissions')!r}"
+    )
+
+
+def test_concurrency_serializes_per_ref_without_cancelling() -> None:
+    """Runs queue per ref instead of cancelling one another."""
+    concurrency = _load().get("concurrency")
+    assert isinstance(concurrency, dict), "the workflow must declare concurrency"
+    assert concurrency.get("group") == "mutation-testing-${{ github.ref }}", (
+        f"concurrency.group must key on the triggering ref, got "
+        f"{concurrency.get('group')!r}"
+    )
+    assert concurrency.get("cancel-in-progress") is False, (
+        f"concurrency.cancel-in-progress must be false, got "
+        f"{concurrency.get('cancel-in-progress')!r}"
+    )
+
+
+def test_triggers_keep_schedule_and_plain_dispatch() -> None:
+    """The daily schedule stays; dispatch has no legacy branch input."""
+    triggers = _triggers(_load())
+    schedule = triggers.get("schedule")
+    assert schedule == [{"cron": "35 4 * * *"}], (
+        f"on.schedule must be the daily 04:35 UTC cron, got {schedule!r}"
+    )
+    assert "workflow_dispatch" in triggers, "on.workflow_dispatch is missing"
+    dispatch = triggers.get("workflow_dispatch") or {}
+    inputs = dispatch.get("inputs") or {}
+    assert "branch" not in inputs, (
+        "on.workflow_dispatch must not declare a branch input; the Actions "
+        "run-workflow control selects the ref"
+    )
+
+
+def test_with_block_carries_the_caller_configuration() -> None:
+    """The caller passes exactly the paths, exclusions, and feature args."""
+    with_block = _mutation_job(_load()).get("with")
+    assert isinstance(with_block, dict), "jobs.mutation.with is missing"
+    assert with_block == EXPECTED_WITH, (
+        "jobs.mutation.with must be exactly the documented configuration "
+        f"(paths, exclude-globs, extra-args): expected {EXPECTED_WITH!r}, "
+        f"got {with_block!r}"
+    )


### PR DESCRIPTION
## Summary

This pull request adopts the shared mutation-testing reusable workflow for chutoro as a thin caller of `leynos/shared-actions` `mutation-cargo.yml`, pinned to `47aea18960d24f33aedc4782ec6b73e365418313`. Runs are informational only: a daily scheduled guard at 04:35 UTC mutates recently changed files, and manual dispatch runs mutate the full tree fanned out across shards.

## Configuration for this repository

- **`paths: "chutoro-core/,chutoro-cli/,chutoro-providers/,chutoro-benches/"`** — the workspace crates live in top-level directories rather than a root `src/`. `chutoro-test-support` (test scaffolding) and the root `verus/` proof files are deliberately left outside, as mutants there would only produce noise survivors.
- **`exclude-globs`** — removes the Kani proof modules (`chutoro-core/src/hnsw/kani_proofs/**`, `chutoro-providers/dense/src/simd/kani_proofs.rs`), which only compile under `cargo kani` in the nightly Kani workflow; the unconditionally compiled `chutoro-core/src/hnsw/insert/test_helpers.rs`; and the out-of-workspace `session_api_without_cpu` test fixture crate under `chutoro-core/tests/fixtures/`. All other test helpers in the tree are `cfg(test)`-gated, which cargo-mutants already skips.
- **`extra-args: "--all-features"`** — mirrors the CI test baseline (`make test` runs nextest with `--all-features`) so feature-gated tests run against mutants.

A contract test suite at `tests/workflow_contracts/mutation_testing_test.py` pins the caller's SHA, least-privilege permissions, per-ref concurrency, triggers, and the exact `with:` block. It runs in the `build-test` CI job (after Lint) via the new `make test-workflow-contracts` target using uv.

## Validation

- YAML parse of both workflows passes.
- actionlint reports no issues on `mutation-testing.yml` and `ci.yml`.
- `make test-workflow-contracts`: 6 passed, including a negative test (temporarily repointing the pin at `@v1` correctly fails the SHA assertion before restoration).

References: [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md) and the estate template PR [leynos/wireframe#572](https://github.com/leynos/wireframe/pull/572).
