### PR TITLE
Test the whole workspace against mutants and bump the workflow pin

### DIFF
--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -26,7 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@47aea18960d24f33aedc4782ec6b73e365418313
+    uses: leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503
     with:
       # Workspace crates live in top-level directories, not a root
       # src/. chutoro-test-support (test scaffolding) and the root
@@ -38,6 +38,7 @@ jobs:
       # scaffolding, and the session_api_without_cpu fixture crate sits
       # outside the workspace; mutants in any of them are noise.
       exclude-globs: "chutoro-core/src/hnsw/kani_proofs/**,chutoro-providers/dense/src/simd/kani_proofs.rs,chutoro-core/src/hnsw/insert/test_helpers.rs,chutoro-core/tests/fixtures/**"
-      # Match the CI baseline (`make test` runs --all-features) so
-      # feature-gated tests run against mutants.
-      extra-args: "--all-features"
+      # Match the CI baseline (`make test` runs nextest workspace-wide
+      # with --all-features) so feature-gated tests run against mutants
+      # and dependent crates' tests catch cross-crate survivors.
+      extra-args: "--all-features --test-workspace=true"

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -21,10 +21,10 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA of the shared workflow pin (the merge commit of
-#: leynos/shared-actions PR #319). Bump the workflow and this test
-#: together.
-PINNED_SHA = "47aea18960d24f33aedc4782ec6b73e365418313"
+#: The commit SHA of the shared workflow pin (leynos/shared-actions
+#: main, adding artefact preservation on timeout). Bump the workflow
+#: and this test together.
+PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
@@ -33,7 +33,8 @@ EXPECTED_USES = (
 #: The exact caller configuration: workspace crate paths (the repo has
 #: no root src/; chutoro-test-support and verus/ stay outside), the
 #: Kani-proof and scaffolding exclusions, and the --all-features
-#: baseline mirrored from `make test`.
+#: --test-workspace=true baseline: `make test` runs the whole workspace,
+#: so dependent crates' tests must also run against each mutant.
 EXPECTED_WITH = {
     "paths": "chutoro-core/,chutoro-cli/,chutoro-providers/,chutoro-benches/",
     "exclude-globs": (
@@ -42,7 +43,7 @@ EXPECTED_WITH = {
         "chutoro-core/src/hnsw/insert/test_helpers.rs,"
         "chutoro-core/tests/fixtures/**"
     ),
-    "extra-args": "--all-features",
+    "extra-args": "--all-features --test-workspace=true",
 }
 
 


### PR DESCRIPTION
## Summary

A review finding on rstest-bdd#569 applies estate-wide: cargo-mutants runs only the mutated package's tests by default, so workspace crates whose coverage lives in dependent crates' tests report false survivors. chutoro's CI baseline is workspace-wide — `make test` runs `cargo nextest run --all-targets --all-features` from the virtual workspace root with no package filters — so mutant runs should match it.

## Changes

- Appends `--test-workspace=true` to `extra-args` in `.github/workflows/mutation-testing.yml`, so every mutant is exercised by the whole workspace's tests and cross-crate coverage (for example, `chutoro-cli` tests exercising `chutoro-core`) kills mutants it already covers.
- Bumps the shared-workflow pin from `47aea18960d24f33aedc4782ec6b73e365418313` to `2b09d10192627fd6e1034e7c12625dd266b45503`, which adds artefact preservation when a shard times out.
- Updates the contract test's `PINNED_SHA` and expected `extra-args` accordingly.

## Validation

- YAML parse of `mutation-testing.yml` passes.
- actionlint reports no issues.
- `make test-workflow-contracts`: 6 passed.

References: [caller guide](https://github.com/leynos/shared-actions/blob/main/docs/mutation-cargo-workflow.md) and the estate template PR [leynos/wireframe#572](https://github.com/leynos/wireframe/pull/572).
