### PR TITLE
Wire the CodeScene coverage gate

### DIFF
--- a/.github/workflows/benchmark-regressions.yml
+++ b/.github/workflows/benchmark-regressions.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Resolve benchmark CI mode
         id: gate
         env:
@@ -63,7 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Run benchmark discovery smoke check
         run: |
           set -o pipefail
@@ -105,7 +105,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Resolve benchmark reference commit
         id: reference
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,38 +58,16 @@ jobs:
           # but fails under plain cargo test, so coverage stays on nextest.
           use-cargo-nextest: 'true'
           with-ratchet: 'true'
-      # `cs-coverage check` fails hard when the CodeScene project has no
-      # gates configuration (set once in CodeScene's UI, not from CI).
-      # Estate policy wires the repository first and enables the
-      # CodeScene-side gate second, so probe the project config and skip
-      # the gate until it exists; the gate becomes enforcing on its own
-      # once the configuration is saved in CodeScene.
-      - name: Detect CodeScene coverage gates
-        id: cs-gates
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          set -euo pipefail
-          body=$(curl -fsS -H "Authorization: Bearer ${CS_ACCESS_TOKEN}" \
-            https://api.codescene.io/v2/code-coverage/projects/71838/config)
-          if [ -n "$body" ]; then
-            echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "configured=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::CodeScene project 71838 has no coverage gates configuration; skipping the coverage gate."
-          fi
-      - name: Check coverage against CodeScene gates
-        env:
-          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: env.CS_ACCESS_TOKEN != '' && steps.cs-gates.outputs.configured == 'true'
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
-        with:
-          format: lcov
-          mode: check
-          project-url: https://api.codescene.io/v2/projects/71838
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
+      # The `mode: check` step is deliberately not wired in yet: CodeScene
+      # project 71838 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint's project hit the byte-identical error). Add the
+      # check step in a fast-follow PR once coverage-main.yml has
+      # uploaded to main at least once and the gate is confirmed to
+      # resolve, or once CodeScene confirms the project's coverage gate
+      # is enabled.
 
   verus-proofs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,31 @@ jobs:
           # but fails under plain cargo test, so coverage stays on nextest.
           use-cargo-nextest: 'true'
           with-ratchet: 'true'
-      - name: Check coverage against CodeScene gates
+      # `cs-coverage check` fails hard when the CodeScene project has no
+      # gates configuration (set once in CodeScene's UI, not from CI).
+      # Estate policy wires the repository first and enables the
+      # CodeScene-side gate second, so probe the project config and skip
+      # the gate until it exists; the gate becomes enforcing on its own
+      # once the configuration is saved in CodeScene.
+      - name: Detect CodeScene coverage gates
+        id: cs-gates
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != ''
+        run: |
+          set -euo pipefail
+          body=$(curl -fsS -H "Authorization: Bearer ${CS_ACCESS_TOKEN}" \
+            https://api.codescene.io/v2/code-coverage/projects/71838/config)
+          if [ -n "$body" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CodeScene project 71838 has no coverage gates configuration; skipping the coverage gate."
+          fi
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && steps.cs-gates.outputs.configured == 'true'
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,12 @@ jobs:
       BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          # cs-coverage check diffs the PR against its merge base, so the
+          # full history must be fetched for the merge base to be reachable.
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Dense stable SIMD gating
         run: |
           cargo clippy -p chutoro-providers-dense \
@@ -46,17 +50,23 @@ jobs:
       - name: Workflow contract tests
         run: make test-workflow-contracts
       - name: Test and Measure Coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           output-path: lcov.info
           format: lcov
-      - name: Upload coverage data to CodeScene
+          # chutoro#155: one test passes under nextest's process isolation
+          # but fails under plain cargo test, so coverage stays on nextest.
+          use-cargo-nextest: 'true'
+          with-ratchet: 'true'
+      - name: Check coverage against CodeScene gates
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-        if: ${{ env.CS_ACCESS_TOKEN }}
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
           format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/71838
           access-token: ${{ env.CS_ACCESS_TOKEN }}
           installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,44 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# changed-line gate (`cs-coverage check`) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+
+'on':
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Test and Measure Coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: lcov.info
+          format: lcov
+          # chutoro#155: one test passes under nextest's process isolation
+          # but fails under plain cargo test, so coverage stays on nextest.
+          use-cargo-nextest: 'true'
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          project-url: https://api.codescene.io/v2/projects/71838
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/nightly-kani.yml
+++ b/.github/workflows/nightly-kani.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           ref: main
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Decide whether to run Kani
         id: gate
         env:

--- a/.github/workflows/property-tests.yml
+++ b/.github/workflows/property-tests.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - &setup_rust_step
         name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@aebb3f5b831102e2a10ef909c83d7d50ea86c332
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - &install_nextest_step
         name: Install cargo-nextest
         run: cargo binstall --no-confirm cargo-nextest


### PR DESCRIPTION
## Summary

Onboards chutoro to the CodeScene coverage rollout (CodeScene project
[71838](https://codescene.io/projects/71838)), following the estate
pattern proven in [mxd#362](https://github.com/leynos/mxd/pull/362).

The CodeScene app can post a `Code Coverage` check on every pull-request
head and wait for coverage data for that commit. A repository that
generates coverage but never feeds CodeScene leaves that check hanging
until it times out, and a timed-out check poisons the whole status
rollup — Dependabot automerge reads the rollup, so it never fires even
when every required check (`build-test`, `verus-proofs`) is green. Note
the coverage check is **not** a ruleset-required check; it blocks
through the rollup, not the branch protection contract.

This PR wires the CI side:

- A new `coverage-main.yml` uploads coverage on push to `main` with the
  shared `upload-codescene-coverage` action's default `mode: upload` —
  CodeScene accepts uploads only from analysed branches — feeding the
  dashboard and writing the authoritative ratchet baseline.
- The coverage ratchet is enabled (`with-ratchet: 'true'`) on both the
  pull-request coverage job and the main-push workflow, so line coverage
  cannot silently regress; the main-push run writes the baseline every
  pull-request run compares against.
- The `build-test` checkout gains `fetch-depth: 0` so the changed-line
  gate (`mode: check`) can diff against the merge base when it lands.
- Every shared-actions **composite-action** pin (`setup-rust`,
  `generate-coverage`, `upload-codescene-coverage`) moves to a single
  repo-wide SHA `927edd45`; the coverage actions require at least that
  SHA. The `mutation-cargo` and `dependabot-automerge` reusable
  workflows keep their own Dependabot-managed pins (the former is
  guarded by a workflow-contract test).
- The pull-request `mode: check` gate is **deliberately deferred**: an
  estate-wide finding (first hit here and on ddlint) is that
  `cs-coverage check` fails unconditionally on any CodeScene project
  whose configuration lacks a gates section — "received project-config
  isn't valid. Lacks the gates configuration" — and only mxd's project
  has one today. That configuration is a CodeScene-side per-project
  setting, outwith CI's reach, so the gate lands in a small fast-follow
  PR once main has uploaded coverage and the project's gates
  configuration exists. A comment in `ci.yml` records the deferral.

Coverage stays on nextest (`use-cargo-nextest: 'true'`): per
[chutoro#155](https://github.com/leynos/chutoro/issues/155) a test that
passes under nextest's process isolation fails under plain `cargo test`,
so downgrading to plain `cargo llvm-cov` is off the table.

`CS_ACCESS_TOKEN` has been set in both the Actions and Dependabot secret
stores, so Dependabot-triggered runs (which read a separate store) also
upload.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/chutoro/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  — `fetch-depth: 0` checkout, ratchet enabled on the coverage step,
  composite pins bumped, deferred-gate comment. The coverage wiring
  remains in `build-test`; `verus-proofs` is untouched.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/chutoro/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  — new push-to-main upload workflow.
- [`benchmark-regressions.yml`](https://github.com/leynos/chutoro/blob/codescene-coverage-gate/.github/workflows/benchmark-regressions.yml),
  [`property-tests.yml`](https://github.com/leynos/chutoro/blob/codescene-coverage-gate/.github/workflows/property-tests.yml),
  [`nightly-kani.yml`](https://github.com/leynos/chutoro/blob/codescene-coverage-gate/.github/workflows/nightly-kani.yml)
  — `setup-rust` pin bumps only.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on `ci.yml` and
  `coverage-main.yml` — parse clean.
- `make test-workflow-contracts` — 6 passed (the mutation-testing caller
  contract is unaffected).
- CI on this PR head exercises the bumped pins and the ratcheted
  coverage generation end to end.
