### PR TITLE
Grant the dataset recipe trybuild check the trybuild timeout

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -82,7 +82,7 @@ retries = 1
 [[profile.default.overrides]]
 # Trybuild compile checks build fixture crates in isolated target directories
 # and can exceed the generic 60s timeout on shared developer machines.
-filter = "test(/portable_simd_gating_compile_checks|session_api_compiles_when_cpu_feature_is_enabled/)"
+filter = "test(/portable_simd_gating_compile_checks|session_api_compiles_when_cpu_feature_is_enabled|dataset_recipe_phase_order/)"
 threads-required = 4
 slow-timeout = { period = "300s", terminate-after = 1, grace-period = "5s" }
 
@@ -135,6 +135,6 @@ retries = 1
 [[profile.ci.overrides]]
 # Trybuild compile checks build fixture crates in isolated target directories
 # and can exceed the generic 60s timeout on shared runners.
-filter = "test(/portable_simd_gating_compile_checks|session_api_compiles_when_cpu_feature_is_enabled/)"
+filter = "test(/portable_simd_gating_compile_checks|session_api_compiles_when_cpu_feature_is_enabled|dataset_recipe_phase_order/)"
 threads-required = 4
 slow-timeout = { period = "300s", terminate-after = 1, grace-period = "5s" }


### PR DESCRIPTION
## Summary

The first `coverage-main.yml` run on main
([29041464625](https://github.com/leynos/chutoro/actions/runs/29041464625))
failed with a single test timeout:
`chutoro-bench-datasets::recipe_api_surface dataset_recipe_phase_order`
hit nextest's generic 60 s slow-timeout under llvm-cov instrumentation.
The test is a trybuild compile check — it builds fixture crates in an
isolated target directory, exactly the class of test the nextest
configuration already grants 300 s (`portable_simd_gating_compile_checks`,
`session_api_compiles_when_cpu_feature_is_enabled`). The pull-request
run of the identical coverage step passed, so the margin is timing, not
correctness.

This adds `dataset_recipe_phase_order` to the existing trybuild timeout
override filter in both the `default` and `ci` profiles.

## Review walkthrough

- [`.config/nextest.toml`](https://github.com/leynos/chutoro/blob/coverage-trybuild-timeout/.config/nextest.toml)
  — two-line change: the trybuild override filter in each profile gains
  the new test name; the 300 s period, `threads-required`, and grace
  period are unchanged.

## Validation

- `python3 -c "import tomllib; tomllib.load(...)"` — parse clean.
- The `coverage-main.yml` run after merge is the live proof: the upload
  to CodeScene project 71838 and the ratchet baseline save follow the
  suite completing.
