### PR TITLE
Make edge-harvest consistency test deterministic

### DIFF
--- a/chutoro-core/src/hnsw/tests/edge_harvest/coverage.rs
+++ b/chutoro-core/src/hnsw/tests/edge_harvest/coverage.rs
@@ -1,6 +1,7 @@
 //! Edge-harvest coverage and ordering tests.
 
 use super::*;
+use crate::hnsw::tests::support::is_coverage_job;
 
 #[rstest]
 fn build_with_edges_covers_inserted_nodes() {

--- a/chutoro-core/src/hnsw/tests/edge_harvest/mod.rs
+++ b/chutoro-core/src/hnsw/tests/edge_harvest/mod.rs
@@ -14,7 +14,6 @@ use crate::hnsw::types::{InsertionPlan, LayerPlan};
 use crate::hnsw::{CandidateEdge, CpuHnsw, EdgeHarvest, HnswError, HnswParams, Neighbour};
 
 use super::fixtures::DummySource;
-use super::support::is_coverage_job;
 
 fn build_insertion_plan(layers: Vec<Vec<(usize, f32)>>) -> InsertionPlan {
     InsertionPlan {
@@ -225,6 +224,27 @@ fn build_with_edges_returns_valid_edges(
     }
 }
 
+/// Builds an index with edge harvesting inside a dedicated single-threaded
+/// Rayon pool, making insertion order (and therefore the harvested edges)
+/// fully deterministic for a given seed.
+fn build_with_edges_single_threaded(
+    data: Vec<f32>,
+    max_connections: usize,
+    ef_construction: usize,
+    seed: u64,
+) -> (CpuHnsw, EdgeHarvest) {
+    let source = DummySource::new(data);
+    let params = HnswParams::new(max_connections, ef_construction)
+        .expect("params")
+        .with_rng_seed(seed);
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(1)
+        .build()
+        .expect("single-threaded Rayon pool");
+    pool.install(|| CpuHnsw::build_with_edges(&source, params))
+        .expect("build must succeed")
+}
+
 #[rstest]
 #[case(5, 2, 4, 42)]
 #[case(10, 4, 8, 123)]
@@ -234,57 +254,32 @@ fn build_with_edges_has_consistent_count(
     #[case] ef_construction: usize,
     #[case] seed: u64,
 ) {
-    // Due to Rayon's non-deterministic thread scheduling, parallel insertions
-    // can happen in different orders between runs. This affects the HNSW graph
-    // structure and thus which candidate edges are discovered.
+    // Rayon's thread scheduling makes parallel insertion order — and hence
+    // the harvested edges — non-deterministic on the shared global pool, and
+    // the variance grows with pool contention from concurrently running
+    // tests. Comparing counts under a tolerance was therefore flaky under
+    // plain `cargo test`, where every test shares one process (issue #155).
     //
-    // We verify that multiple builds produce a similar number of edges (within
-    // some tolerance), rather than requiring exact equality.
+    // Instead, run each build inside its own single-threaded Rayon pool:
+    // insertions proceed in node order on one worker with a deterministic
+    // per-worker RNG, so two same-seed builds must produce identical
+    // harvests regardless of what else the process is running.
     let data: Vec<f32> = (0..num_nodes).map(|i| i as f32).collect();
-    let source1 = DummySource::new(data.clone());
-    let source2 = DummySource::new(data);
 
-    let params1 = HnswParams::new(max_connections, ef_construction)
-        .expect("params")
-        .with_rng_seed(seed);
-    let params2 = HnswParams::new(max_connections, ef_construction)
-        .expect("params")
-        .with_rng_seed(seed);
+    let (index1, edges1) =
+        build_with_edges_single_threaded(data.clone(), max_connections, ef_construction, seed);
+    let (index2, edges2) =
+        build_with_edges_single_threaded(data, max_connections, ef_construction, seed);
 
-    let (index1, edges1) = CpuHnsw::build_with_edges(&source1, params1).expect("build 1");
-    let (index2, edges2) = CpuHnsw::build_with_edges(&source2, params2).expect("build 2");
-
-    // Both builds should produce the same number of nodes
     assert_eq!(index1.len(), index2.len(), "index sizes must match");
-
-    // Edge counts should be within reasonable tolerance (±50%)
-    // since graph structure can vary with insertion order.
-    // Coverage instrumentation can significantly affect Rayon's thread scheduling,
-    // causing more variance in parallel insertion order and thus edge counts.
-    let min_edges = edges1.len().min(edges2.len());
-    let max_edges = edges1.len().max(edges2.len());
-    // Half the midpoint is a symmetric 50% tolerance. Basing the allowance on
-    // only the smaller sample made the accepted variance depend on build order.
-    let base_tolerance = min_edges.saturating_add(max_edges).div_ceil(4).max(2);
-    // Under coverage instrumentation, Rayon's thread scheduling is
-    // significantly perturbed, causing insertion order to vary more
-    // than in a standard build. The variance in harvested edge counts
-    // scales with max_connections × ef_construction: ef_construction
-    // bounds the candidate search width per insertion, and
-    // max_connections bounds the neighbourhood retained.
-    let coverage_tolerance = if is_coverage_job() {
-        max_connections * ef_construction
-    } else {
-        0
-    };
-    let tolerance = base_tolerance + coverage_tolerance;
-
-    assert!(
-        max_edges <= min_edges + tolerance,
-        "edge counts should be similar: {} vs {} (tolerance: {})",
+    assert_eq!(
         edges1.len(),
         edges2.len(),
-        tolerance
+        "same-seed single-threaded builds must harvest the same edge count",
+    );
+    assert_eq!(
+        edges1, edges2,
+        "same-seed single-threaded builds must harvest identical edges",
     );
 }
 


### PR DESCRIPTION
Closes #155.

The first scheduled mutation-testing run failed its unmutated baseline
because `hnsw::tests::edge_harvest::build_with_edges_has_consistent_count::case_1`
passes under CI's `cargo nextest` (one process per test) but fails under
the plain `cargo test` that cargo-mutants uses. This PR removes the
test's dependence on process isolation so the baseline is stable.

## Diagnosis

The test built the same seeded index twice on Rayon's shared global
pool and asserted the two harvested edge counts fell within a ±50%
tolerance. Insertion order — and therefore the HNSW graph structure and
the edges harvested — depends on Rayon scheduling, and the variance
grows with contention on the pool from concurrently running tests.
Under nextest each test owns its process, so the pool is uncontended
and the spread stays small. Under plain `cargo test`, tests share one
process; even the sibling `rstest` case alone was enough to breach the
tolerance:

- Run alone, single-threaded: 10/10 passes.
- Run with only its sibling case in the same process: 2 failures in 10
  runs, e.g. `edge counts should be similar: 24 vs 10 (tolerance: 5)`.

So the failure is contention-dependent rather than seed- or
RNG-related, and the full 527-test binary that cargo-mutants runs makes
it far more likely still.

## Fix

[`chutoro-core/src/hnsw/tests/edge_harvest/mod.rs`](https://github.com/leynos/chutoro/blob/fix-mutation-baseline/chutoro-core/src/hnsw/tests/edge_harvest/mod.rs)
— each build now runs inside its own single-threaded Rayon pool
(`ThreadPoolBuilder::num_threads(1)` + `pool.install`). Insertions then
proceed in node order on one worker with a deterministic per-worker
RNG, so two same-seed builds must produce identical harvests. The
tolerance heuristic (including its coverage-instrumentation widening)
is replaced with exact equality of both the edge count and the full
`EdgeHarvest`, which is strictly stronger and independent of the test
runner's process model, scheduler behaviour, and machine load.

The genuinely parallel construction path remains exercised by
`build_with_edges_returns_valid_edges`, whose assertions are
scheduling-independent invariants, and by the coverage tests in
[`chutoro-core/src/hnsw/tests/edge_harvest/coverage.rs`](https://github.com/leynos/chutoro/blob/fix-mutation-baseline/chutoro-core/src/hnsw/tests/edge_harvest/coverage.rs).

No caller-configuration change is needed: the workflow's
`extra-args: "--all-features --test-workspace=true"` is correct; only
the test was at fault.

## Validation

- `cargo test --all-features --workspace` (the cargo-mutants baseline
  configuration): three consecutive runs, all green, no failures.
- `make test` (nextest, `--all-features`): 993 passed, 1 skipped.
- `make typecheck`, `make check-fmt`, `make markdownlint`: green.
- `make lint-clippy`: green.
- `make lint-whitaker` with the locally installed Whitaker suite fails
  on `no_unwrap_or_else_panic` in
  `chutoro-core/src/hnsw/tests/property/graph_topology_tests/tests.rs:273`,
  a file untouched by this diff and unchanged since #71. This appears
  to be a newer local suite than CI's pinned `whitaker-installer`
  0.2.5; reported here rather than fixed, as it is pre-existing.
