### PR TITLE
Allow manual dispatch of the main coverage upload

### DIFF
--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -10,6 +10,9 @@ name: Coverage (main)
 'on':
   push:
     branches: [main]
+  # Manual dispatch allows re-running the upload (and re-seeding the
+  # ratchet baseline) without waiting for the next push to main.
+  workflow_dispatch:
 
 jobs:
   coverage-upload:


### PR DESCRIPTION
## Summary

The `Coverage (main)` run for the Dylint adoption merge
([29060095342](https://github.com/leynos/chutoro/actions/runs/29060095342))
failed in the coverage ratchet, not the test suite: all 992 tests
passed, but line coverage fell from the stored 85.37% baseline to
85.20% because the merge added uncovered code. The ratchet did its job.
The stale baseline cache has since expired from the Actions cache, so
the next main-branch run will re-seed the baseline at the honest
current figure — but the only trigger today is a push to main.

This adds a `workflow_dispatch` trigger to `coverage-main.yml` so the
upload (and the ratchet baseline re-seed) can be re-run on demand.

## Review walkthrough

- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/chutoro/blob/coverage-main-dispatch/.github/workflows/coverage-main.yml)
  — three lines: the `workflow_dispatch:` trigger with a comment. No
  job changes.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` — parse clean.
- `make test-workflow-contracts` — 6 passed.
- After merge, the push-triggered `Coverage (main)` run re-seeds the
  baseline and a manual dispatch verifies the workflow is repeatably
  green.

## Summary by Sourcery

CI:
- Add a workflow_dispatch trigger to the main coverage GitHub Actions workflow for manual execution.