### PR TITLE
Align spelling helper with Weaver baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,8 +83,8 @@ spelling-config: spelling-helper-test ## Generate and verify the spelling config
 	@$(TYPOS_CONFIG_BUILDER) --repository . --check
 
 spelling-helper-test: ## Validate the shared spelling-policy integration
-	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) format --isolated --target-version py314 --check $(SPELLING_PY_SRCS)
-	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) check --isolated --target-version py314 $(SPELLING_PY_SRCS)
+	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) format --isolated --target-version py313 --check $(SPELLING_PY_SRCS)
+	@$(UV_ENV) $(UV) tool run ruff@$(RUFF_VERSION) check --isolated --target-version py313 $(SPELLING_PY_SRCS)
 	@$(SPELLING_HELPER_PYTEST) $(SPELLING_PY_TESTS) -c /dev/null --rootdir=. -p no:cacheprovider $(SPELLING_COVERAGE_ARGS)
 
 nixie: ## Validate Mermaid diagrams

--- a/scripts/typos_rollout_check.py
+++ b/scripts/typos_rollout_check.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv run python
 # /// script
-# requires-python = ">=3.14"
+# requires-python = ">=3.13"
 # dependencies = ["pathspec==1.1.1"]
 # ///
 """Enforce exact phrase corrections alongside the Typos scanner."""
@@ -163,7 +163,7 @@ def check_phrase_corrections(
             continue
         try:
             text = (repository / relative).read_text(encoding="utf-8")
-        except OSError, UnicodeDecodeError:
+        except (OSError, UnicodeDecodeError):
             continue
         masked = _masked(text, policy.ignore_patterns)
         found.extend(


### PR DESCRIPTION
## Summary

- declare the spelling helper compatible with Python 3.13
- use the approved Weaver Python 3.13 Ruff syntax policy
- retain explicit Python 3.14 execution in the spelling gate

## Validation

- Python 3.13 and explicit 3.14 helper tests: 3 passed at 95.45% coverage
- spelling config and generated policy determinism: passed
- formatting, type checking, rustdoc, Clippy and Whitaker: passed
- 993 tests passed, one skipped; doctests and build passed
- six workflow contracts, Markdownlint, Nixie, Actionlint, Mbake and Checkmake: passed
