### PR TITLE
Stop pinning the exact shared-actions SHA in the mutation contract

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -198,6 +198,41 @@ Use `.github/workflows/property-tests.yml` and `.config/nextest.toml` for the
 authoritative configuration, and `docs/property-testing-design.md` for the
 architectural rationale.
 
+### Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Dense SIMD parity suite
 
 Dense Euclidean backend parity tests live in

--- a/tests/workflow_contracts/mutation_testing_test.py
+++ b/tests/workflow_contracts/mutation_testing_test.py
@@ -8,11 +8,16 @@ at a branch, widening permissions, or losing the paths, exclusions, and
 feature configuration) fails CI on the pull request rather than
 surfacing in a scheduled or manual run.
 
+The caller must reference the correct reusable workflow at a commit SHA;
+Dependabot owns the SHA value, so these tests assert the shape of the pin
+(a 40-hex commit SHA on the correct path) rather than a specific value.
+
 Run via ``make test-workflow-contracts``.
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -21,13 +26,8 @@ WORKFLOW_PATH = (
     Path(__file__).resolve().parents[2] / ".github" / "workflows" / "mutation-testing.yml"
 )
 
-#: The commit SHA of the shared workflow pin (leynos/shared-actions
-#: main, adding artefact preservation on timeout). Bump the workflow
-#: and this test together.
-PINNED_SHA = "2b09d10192627fd6e1034e7c12625dd266b45503"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-cargo.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: workspace crate paths (the repo has
@@ -70,25 +70,13 @@ def _mutation_job(workflow: dict[str, object]) -> dict[str, object]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call the correct shared workflow at a full commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-cargo.yml", (
-        f"jobs.mutation.uses must reference mutation-cargo.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the test together with the workflow"
+    assert USES_RE.match(uses), (
+        f"jobs.mutation.uses must reference mutation-cargo.yml pinned to a "
+        f"40-hex commit SHA (not a branch or tag), got {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the exact-SHA equality assertion in `tests/workflow_contracts/mutation_testing_test.py` with a shape assertion (`leynos/shared-actions/.github/workflows/mutation-cargo.yml@<40-hex sha>`), so Dependabot bumps of the caller's pin no longer fail CI.
- Drop the now-unused `PINNED_SHA` / `EXPECTED_USES` constants and update the module docstring to describe the shape contract instead of a pinned value.
- Document the policy — assert path and SHA shape, never the specific value — in a new "Workflow pins and Dependabot" subsection of `docs/developers-guide.md`, under Continuous integration.

## Review walkthrough

- `tests/workflow_contracts/mutation_testing_test.py`: `test_uses_reference_is_pinned_to_the_documented_sha` is renamed to `test_uses_reference_is_pinned_to_a_commit_sha` and now matches `USES_RE` (path + 40-hex SHA) instead of comparing against a hard-coded `EXPECTED_USES`. All other assertions (job permissions, workflow-level permissions, concurrency, triggers, `with`-block configuration) are unchanged.
- `docs/developers-guide.md`: adds the estate-wide policy text on why contract tests must not pin an exact SHA, with the recommended regex-based pattern.
- `.github/dependabot.yml` already has a `github-actions` ecosystem entry with `directory: "/"` (weekly schedule) — no change needed there.
- This PR does not touch `.github/workflows/**`, so it should not need workflow-scope OAuth permissions to merge.

## Validation

- `make test-workflow-contracts` — 6 passed, confirming the new regex matches the workflow's current pin (`leynos/shared-actions/.github/workflows/mutation-cargo.yml@2b09d10192627fd6e1034e7c12625dd266b45503`).
- Reasoned check: the regex `^leynos/shared-actions/\.github/workflows/mutation-cargo\.yml@[0-9a-f]{40}$` matches any 40-character lowercase-hex SHA on that path, so a future Dependabot bump to a different SHA will also pass, while a repoint to a branch/tag (e.g. `@main`) still fails.
