### PR TITLE
Wire the CodeScene mode: check coverage gate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,16 +88,17 @@ jobs:
           # but fails under plain cargo test, so coverage stays on nextest.
           use-cargo-nextest: 'true'
           with-ratchet: 'true'
-      # The `mode: check` step is deliberately not wired in yet: CodeScene
-      # project 71838 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint's project hit the byte-identical error). Add the
-      # check step in a fast-follow PR once coverage-main.yml has
-      # uploaded to main at least once and the gate is confirmed to
-      # resolve, or once CodeScene confirms the project's coverage gate
-      # is enabled.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/71838
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}
 
   verus-proofs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- CodeScene's coverage gate is now enabled for chutoro's project
  (71838), so `cs-coverage check` no longer fails with "HTTP call
  succeeded, but the received project-config isn't valid. Lacks the
  gates configuration."
- Replace the deferred-gate comment in `ci.yml`'s `build-test` job
  with the guarded `mode: check` step, wired identically to
  `coverage-main.yml`'s `mode: upload` step (same pin, same `lcov`
  format, same `project-url`).
- `verus-proofs` is unaffected; the coverage/check step stays in
  `build-test`, which is the job that already runs
  `generate-coverage` and checks out with `fetch-depth: 0`.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/chutoro/blob/codescene-mode-check/.github/workflows/ci.yml) —
  new `Check coverage against CodeScene gates` step, guarded on
  `CS_ACCESS_TOKEN` being set and the run being a `pull_request`
  event, using the same `927edd4` shared-actions pin already in use
  for `generate-coverage` and `setup-rust`.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — YAML parses.
- `make test-workflow-contracts` — 6 passed, no contract asserts on
  the coverage step shape.
- CI on this PR: confirm the `Check coverage against CodeScene gates`
  step executes (not skipped) and the `CodeScene Code Coverage` check
  completes successfully rather than erroring with the gates-missing
  message.
