### PR TITLE
Make property and HNSW coverage deterministic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,15 @@ jobs:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
       WHITAKER_INSTALLER_VERSION: '0.2.6'
+      # Pin Rayon to a single worker so the HNSW build is deterministic during
+      # coverage. `CpuHnsw::build` inserts nodes through `into_par_iter` and
+      # `sample_level` draws from a per-worker RNG chosen by
+      # `current_thread_index`, so multi-threaded scheduling varies both the
+      # insertion order and the random draws, producing a different graph — and
+      # therefore different covered lines — on each run. That made whole-workspace
+      # coverage wobble run-to-run and false-tripped the ratchet. One worker keeps
+      # the ratchet input reproducible and matched to the coverage-main baseline.
+      RAYON_NUM_THREADS: '1'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -22,6 +22,12 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
+      # Pin Rayon to a single worker so the HNSW build is deterministic during
+      # coverage. This baseline must be measured identically to the pull-request
+      # check in ci.yml (which sets the same variable); otherwise the ratchet
+      # would compare a deterministic PR measurement against a non-deterministic
+      # baseline. See ci.yml for the full rationale.
+      RAYON_NUM_THREADS: '1'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
       - name: Setup Rust

--- a/chutoro-bench-datasets/tests/recipe_proptest.rs
+++ b/chutoro-bench-datasets/tests/recipe_proptest.rs
@@ -5,15 +5,16 @@ use chutoro_bench_datasets::{
     RecipeContext, SourceUrl, run_recipe,
     testing::{InMemoryFetcher, InMemoryPublisher, InMemoryStorage, StubRecipe},
 };
-use chutoro_test_support::ci::property_test_profile::ProptestRunProfile;
+use chutoro_test_support::ci::property_test_profile::{PROPTEST_RNG_SEED, ProptestRunProfile};
 use proptest::prelude::*;
-use proptest::test_runner::Config as ProptestConfig;
+use proptest::test_runner::{Config as ProptestConfig, RngSeed};
 
 fn suite_proptest_config(default_cases: u32) -> ProptestConfig {
     let profile = ProptestRunProfile::load(default_cases, false);
     ProptestConfig {
         cases: profile.cases(),
         fork: profile.fork(),
+        rng_seed: RngSeed::Fixed(PROPTEST_RNG_SEED),
         ..ProptestConfig::default()
     }
 }

--- a/chutoro-core/src/hnsw/tests/property/edge_harvest_output/suite.rs
+++ b/chutoro-core/src/hnsw/tests/property/edge_harvest_output/suite.rs
@@ -240,6 +240,8 @@ mod tests {
     // ========================================================================
 
     proptest! {
+        #![proptest_config(suite_proptest_config(256))]
+
         #[test]
         fn harvested_output_handles_small_random_graph(seed in any::<u64>()) {
             let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);

--- a/chutoro-core/src/hnsw/tests/property/test_runner_support/runner_wrappers.rs
+++ b/chutoro-core/src/hnsw/tests/property/test_runner_support/runner_wrappers.rs
@@ -1,8 +1,9 @@
 //! Proptest execution wrappers for HNSW property tests.
 
+use chutoro_test_support::ci::property_test_profile::PROPTEST_RNG_SEED;
 use proptest::{
     prelude::any,
-    test_runner::{Config, TestCaseError, TestCaseResult, TestError, TestRunner},
+    test_runner::{Config, RngSeed, TestCaseError, TestCaseResult, TestError, TestRunner},
 };
 
 use super::budget_selection::{ShrinkIterations, StackSize, TestCases, property_run_profile};
@@ -45,6 +46,7 @@ where
         cases: cases.get(),
         fork: profile.fork(),
         max_shrink_iters: max_shrink_iters.get(),
+        rng_seed: RngSeed::Fixed(PROPTEST_RNG_SEED),
         ..Config::default()
     })
 }
@@ -220,6 +222,7 @@ where
             cases: runner_config.cases.get(),
             fork: runner_config.fork,
             max_shrink_iters: runner_config.max_shrink_iters.get(),
+            rng_seed: RngSeed::Fixed(PROPTEST_RNG_SEED),
             ..Config::default()
         },
         runner_config.stack_size.get(),

--- a/chutoro-core/src/hnsw/tests/property/tests.rs
+++ b/chutoro-core/src/hnsw/tests/property/tests.rs
@@ -26,6 +26,7 @@ use super::{
 };
 use crate::error::DataSourceError;
 use crate::hnsw::HnswError;
+use crate::test_utils::suite_proptest_config;
 use crate::{CpuHnsw, DataSource};
 
 #[test]
@@ -63,6 +64,8 @@ fn params_seed_build_propagates_errors(
 }
 
 proptest! {
+    #![proptest_config(suite_proptest_config(256))]
+
     #[test]
     fn fixture_dimensions_are_consistent(fixture in hnsw_fixture_strategy()) {
         let dimension = fixture.dimension();
@@ -364,6 +367,8 @@ fn bootstrap_uniform_vectors() -> Vec<Vec<f32>> {
 // ============================================================================
 
 proptest! {
+    #![proptest_config(suite_proptest_config(256))]
+
     #[test]
     fn generated_graphs_are_valid(fixture in graph_fixture_strategy()) {
         run_graph_validity_property(&fixture)?;

--- a/chutoro-core/src/session/tests/properties.rs
+++ b/chutoro-core/src/session/tests/properties.rs
@@ -12,9 +12,12 @@ use std::sync::Arc;
 use proptest::prelude::*;
 
 use super::common::SessionTestSource;
+use crate::test_utils::suite_proptest_config;
 use crate::{CandidateEdge, ChutoroBuilder, ChutoroError, CpuHnsw, DataSource, HnswParams};
 
 proptest! {
+    #![proptest_config(suite_proptest_config(256))]
+
     /// Any non-zero `min_cluster_size` in `[1, 1000]` must yield a session whose
     /// `config().min_cluster_size()` equals the requested value.
     #[test]

--- a/chutoro-core/src/test_utils.rs
+++ b/chutoro-core/src/test_utils.rs
@@ -1,7 +1,7 @@
 //! Shared test utilities for `chutoro-core`.
 
-use chutoro_test_support::ci::property_test_profile::ProptestRunProfile;
-use proptest::test_runner::Config as ProptestConfig;
+use chutoro_test_support::ci::property_test_profile::{PROPTEST_RNG_SEED, ProptestRunProfile};
+use proptest::test_runner::{Config as ProptestConfig, RngSeed};
 
 use crate::{datasource::DataSource, error::DataSourceError};
 use std::sync::{
@@ -19,6 +19,7 @@ pub(crate) fn suite_proptest_config(default_cases: u32) -> ProptestConfig {
     ProptestConfig {
         cases: profile.cases(),
         fork: profile.fork(),
+        rng_seed: RngSeed::Fixed(PROPTEST_RNG_SEED),
         ..ProptestConfig::default()
     }
 }

--- a/chutoro-providers/dense/src/simd/tests/parity/mod.rs
+++ b/chutoro-providers/dense/src/simd/tests/parity/mod.rs
@@ -28,7 +28,8 @@ mod pairwise;
 mod query_points;
 mod strategies;
 
-use proptest::test_runner::Config as ProptestConfig;
+use chutoro_test_support::ci::property_test_profile::PROPTEST_RNG_SEED;
+use proptest::test_runner::{Config as ProptestConfig, RngSeed};
 
 use crate::simd::{DensePointView, dispatch, kernels};
 
@@ -41,7 +42,7 @@ type QueryPointsEntry = fn(&[f32], &DensePointView<'_>, &mut [f32]);
 /// `chutoro_test_support::ci::property_test_profile`; `default_cases` is used
 /// when no CI override is present. The returned [`ProptestConfig`] carries the
 /// selected case count and fork flag.
-fn proptest_config(default_cases: u32) -> ProptestConfig {
+pub(super) fn proptest_config(default_cases: u32) -> ProptestConfig {
     const DEFAULT_FORK: bool = false;
 
     let profile = chutoro_test_support::ci::property_test_profile::ProptestRunProfile::load(
@@ -51,6 +52,7 @@ fn proptest_config(default_cases: u32) -> ProptestConfig {
     ProptestConfig {
         cases: profile.cases(),
         fork: profile.fork(),
+        rng_seed: RngSeed::Fixed(PROPTEST_RNG_SEED),
         ..ProptestConfig::default()
     }
 }

--- a/chutoro-providers/dense/src/simd/tests/point_view.rs
+++ b/chutoro-providers/dense/src/simd/tests/point_view.rs
@@ -76,6 +76,8 @@ fn lane_output_count_limits_writes_to_logical_points(
 }
 
 proptest! {
+    #![proptest_config(super::parity::proptest_config(256))]
+
     #[test]
     fn lane_output_count_matches_saturating_tail_formula(
         point_count in any::<usize>(),

--- a/chutoro-test-support/src/ci/property_test_profile.rs
+++ b/chutoro-test-support/src/ci/property_test_profile.rs
@@ -12,6 +12,21 @@ pub const PROGTEST_CASES_ENV_KEY: &str = "PROGTEST_CASES";
 /// Environment variable controlling proptest process forking.
 pub const CHUTORO_PBT_FORK_ENV_KEY: &str = "CHUTORO_PBT_FORK";
 
+/// Fixed RNG seed applied to every property suite so coverage is deterministic.
+///
+/// By default proptest seeds its runner from operating-system entropy, so each
+/// run explores a different pseudo-random set of cases and touches a different
+/// set of lines. That makes whole-workspace line coverage wobble run-to-run for
+/// identical code and false-trips the coverage ratchet. Pinning the seed keeps
+/// proptest's exploratory value (it still walks a fixed pseudo-random set) while
+/// making the covered lines reproducible. Suites that generate their own RNG
+/// seeds through proptest strategies (for example HNSW build seeds) inherit this
+/// determinism, because those draws are taken from the seeded runner.
+///
+/// Apply it by setting `rng_seed: proptest::test_runner::RngSeed::Fixed(..)` on
+/// the `proptest::test_runner::Config` used by a suite.
+pub const PROPTEST_RNG_SEED: u64 = 0x600D_5EED_C047_0207;
+
 /// Runtime profile for property-test execution.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ProptestRunProfile {


### PR DESCRIPTION
## Summary

Whole-workspace line coverage wobbled run-to-run (85.20–85.69%) for
identical code, which false-tripped the `generate-coverage` ratchet
("Coverage decreased") before the CodeScene gate step could run. This PR
removes both sources of non-determinism so the ratchet input is
reproducible.

## Root causes and fixes

- **Property suites seeded from entropy.** Every `proptest!` runner drew
  its RNG from the operating system, so each run explored a different
  pseudo-random case set and touched a different set of lines. Each suite
  now pins `rng_seed: RngSeed::Fixed(..)`, sourced from a new shared
  `PROPTEST_RNG_SEED` constant in `chutoro-test-support` so the policy has
  a single home. Bare `proptest!` blocks that used the default config now
  adopt the shared seeded config too. Proptest still explores a fixed
  pseudo-random set, so its exploratory value is retained; only the
  exploration is made reproducible.
- **HNSW build was scheduling-dependent.** `CpuHnsw::build` inserts nodes
  through `into_par_iter`, and `sample_level` draws from a per-worker RNG
  selected by `current_thread_index`. Multi-threaded scheduling therefore
  varied both the insertion order and the random draws, producing a
  different graph — and different covered lines in the connectivity-healing
  and reconciliation paths — on each run. The coverage jobs (the
  pull-request check in `ci.yml` and the baseline upload in
  `coverage-main.yml`) now pin `RAYON_NUM_THREADS=1` so both measure the
  ratchet input identically and reproducibly. This is scoped to the
  coverage jobs, so ordinary `make test` runs keep their multi-threaded
  concurrency coverage.

## Validation

- Two consecutive local coverage runs
  (`RAYON_NUM_THREADS=1 cargo llvm-cov nextest --workspace --all-features
  -E 'not kind(bench)'`) now agree **exactly across all 110 files**
  (85.34% line coverage), where the two prior unpinned runs differed
  (85.67% vs 85.34%, diverging only in `hnsw/insert/connectivity.rs` and
  `hnsw/insert/reconciliation.rs`).
- `make check-fmt`, `make lint`, and `make test` (993 passed, 1 skipped)
  all pass. Assertions and test counts are unchanged; only the exploration
  and build scheduling are made deterministic.

## Relationship to the ratchet baseline

The frozen baseline is 85.23%. The deterministic measurement (85.34%) sits
above it, so the ratchet no longer false-trips, and because the value is
now stable the baseline can no longer drift beneath a low wobble draw. The
sibling `generate-coverage` baseline-freeze fix (leynos/shared-actions#353)
remains desirable so the baseline can advance on genuine improvements, but
is not required for this determinism fix.
