### PR TITLE
Bump whitaker-installer to 0.2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.5'
+      WHITAKER_INSTALLER_VERSION: '0.2.6'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ project:
 
     linting every target with all features enabled and denying all warnings.
     Install the `whitaker` wrapper with
-    `cargo install --locked whitaker-installer --version 0.2.5` followed by
+    `cargo install --locked whitaker-installer --version 0.2.6` followed by
     `whitaker-installer`. Per-lint configuration (including
     `no_std_fs_operations` exclusions, each with a rationale comment) lives
     in the root `dylint.toml`. Use `make lint-clippy` for a Clippy-only pass


### PR DESCRIPTION
## What changed and why

This bumps the pinned `whitaker-installer` version from 0.2.5 to 0.2.6.
The Whitaker Dylint suite's rolling release now pins toolchain
`nightly-2026-05-28`, which requires `cargo-dylint` 6.0.1. Installer
0.2.5 provisions `cargo-dylint` 4.1.0, whose driver cannot compile on
that nightly, so the repository's CI lint step has been red.
`whitaker-installer` 0.2.6 fixes this by provisioning `cargo-dylint`
6.0.1, and its prebuilt dependency binaries are now published.

## Changed files

- [`.github/workflows/ci.yml`](https://github.com/leynos/chutoro/blob/bump-whitaker-installer-0.2.6/.github/workflows/ci.yml)
- [`AGENTS.md`](https://github.com/leynos/chutoro/blob/bump-whitaker-installer-0.2.6/AGENTS.md)

## Test plan

- [ ] CI lint step (`make lint` / Whitaker Dylint suite) passes on
      `nightly-2026-05-28` with `whitaker-installer` 0.2.6.
