### PR TITLE
Document mutation-testing workflow contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -233,6 +233,67 @@ If a workflow's behaviour genuinely depends on a feature only present from a
 particular commit onwards, express that as a comment or a changelog note, not
 as a test assertion on the SHA string.
 
+## Mutation-testing workflow contract tests
+
+This repository runs scheduled, informational mutation testing through a thin
+caller workflow, [`.github/workflows/mutation-testing.yml`](../.github/workflows/mutation-testing.yml),
+which delegates to the shared reusable workflow
+`leynos/shared-actions/.github/workflows/mutation-cargo.yml`. The heavy lifting
+— running `cargo-mutants`, sharding, and summarizing survivors — lives in
+`shared-actions`; this repository carries only declarative configuration. The
+run is **informational only**: it never gates a pull request. Survivors are
+reported through the job summary and downloadable artefacts so they can be
+triaged into tests, not enforced as a blocking check.
+
+The workflow runs in two modes. A **daily schedule** fires a change-scoped run
+that mutates only the source files touched within the detection window, so
+quiet days are cheap no-ops. A **manual dispatch** (the Actions "Run workflow"
+control) mutates the whole workspace, fanned out across shards; select a
+branch in that control to exercise a feature branch.
+
+The caller passes a small set of configuration inputs, each carrying intent:
+
+- `paths` — the change-detection globs that decide whether a scheduled run has
+  anything to mutate, bounding the scheduled run to the four workspace crates
+  with production source (`chutoro-core`, `chutoro-cli`, `chutoro-providers`,
+  `chutoro-benches`). The repository has no root `src/`, and
+  `chutoro-test-support` (test scaffolding) and the root `verus/` proof files
+  are deliberately left outside: their survivors would be noise.
+- `exclude-globs` — Kani proof modules (which only compile under `cargo
+  kani`), unconditional insert test helpers, and a fixture crate that sits
+  outside the workspace; mutants in any of them are noise rather than genuine
+  test gaps.
+- `extra-args` — `--all-features --test-workspace=true`, forwarded to
+  `cargo-mutants` so the mutation run matches the CI baseline: `make test`
+  runs `nextest` across the whole workspace with `--all-features`, so
+  `--test-workspace=true` mutates each crate against the full workspace test
+  run rather than only that crate's own tests, letting dependent crates catch
+  cross-crate survivors.
+
+The `uses:` reference pins the shared workflow to a full 40-character commit
+SHA rather than a branch or tag, so a force-push upstream cannot silently
+change what runs here. The contract test asserts only that the pin is a full
+commit SHA, not a particular value, so Dependabot bumps it automatically
+without any accompanying test edit.
+
+Because the caller is configuration rather than code, a contract test
+(`tests/workflow_contracts/mutation_testing_test.py`) pins the shape it must
+uphold, failing the pull request when the caller drifts — repointing the pin
+at a branch, widening the token scope, or dropping a configuration input —
+rather than letting the breakage surface only in a scheduled run. Run it
+locally with `make test-workflow-contracts`. The test validates:
+
+- the `uses:` reference targets `mutation-cargo.yml` pinned to a full commit
+  SHA;
+- the `with:` block carries exactly the expected configuration (the `paths`,
+  `exclude-globs`, and `extra-args` above);
+- job permissions are least-privilege (`contents: read`, `id-token: write`)
+  and the workflow-level default token scope is empty;
+- `concurrency` serializes runs per ref without cancelling one in progress;
+  and
+- the triggers keep the daily schedule and a plain `workflow_dispatch` with no
+  legacy branch input.
+
 ## Dense SIMD parity suite
 
 Dense Euclidean backend parity tests live in


### PR DESCRIPTION
## Summary

- Adds a new `## Mutation-testing workflow contract tests` section to
  `docs/developers-guide.md`, documenting the informational mutation-testing
  caller workflow (`.github/workflows/mutation-testing.yml`) and the contract
  test that pins its shape (`tests/workflow_contracts/mutation_testing_test.py`).
- Permutation B (Rust workspace): the manual-dispatch run mutates the whole
  workspace, and `extra-args` carries `--test-workspace=true` (alongside
  `--all-features`) so each crate is mutated against the full workspace test
  run, matching the `make test` baseline.
- Contract-test style: shape-only. `USES_RE` asserts the pin is a full
  40-hex commit SHA on `mutation-cargo.yml`, not a specific value, so
  Dependabot bumps it without any accompanying test edit. There is no
  `pytestmark` skip guard; this is a Rust repository, so `.github/` is not
  stripped from any sandbox the test runs in.
- Local run command documented: `make test-workflow-contracts` (the Makefile
  target exists and wraps
  `uv run --with 'pytest>=8' --with 'pyyaml>=6' pytest tests/workflow_contracts -q`).
- No table of contents/index list exists inside `docs/developers-guide.md`
  itself (only `##`/`###` headings), so no in-file cross-link was added.
  `docs/contents.md` indexes whole documents, not developer's-guide
  subsections, and already lists the developer's guide, so it needed no
  change either.
- No roadmap or execplan tracking applies to this change; checked
  `docs/roadmap.md` and `docs/execplans/*` and found no open item referencing
  the mutation-testing workflow or its contract test.

## Docs lint

`make markdownlint` (spelling/typos check plus `markdownlint-cli2`) passes
cleanly against the full doc set, including the new section.

## Test plan

- [x] `make markdownlint`
- [ ] No Rust/Python test suite run (docs-only change, per brief)

Edited file: `docs/developers-guide.md`.
