### PR TITLE
Make test helpers fallible to satisfy Whitaker 0.2.7 (#193)

### DIFF
--- a/chutoro-core/src/hnsw/insert/executor/tests/mod.rs
+++ b/chutoro-core/src/hnsw/insert/executor/tests/mod.rs
@@ -5,6 +5,8 @@
 
 mod trimming_fixtures;
 
+use std::error::Error;
+
 use super::*;
 use crate::hnsw::insert::{
     reconciliation::EdgeReconciler,
@@ -23,30 +25,34 @@ use trimming_fixtures::{
     verify_post_trim_reciprocity,
 };
 
-fn setup_basic_graph(max_connections: usize, ef_construction: usize, capacity: usize) -> Graph {
-    let params =
-        HnswParams::new(max_connections, ef_construction).expect("params should be valid in tests");
-    Graph::with_capacity(params, capacity)
+fn setup_basic_graph(
+    max_connections: usize,
+    ef_construction: usize,
+    capacity: usize,
+) -> Result<Graph, HnswError> {
+    let params = HnswParams::new(max_connections, ef_construction)?;
+    Ok(Graph::with_capacity(params, capacity))
 }
 
-fn insert_entry_node(graph: &mut Graph, level: usize) {
-    graph
-        .insert_first(NodeContext {
-            node: 0,
-            level,
-            sequence: 0,
-        })
-        .expect("insert entry");
+fn insert_entry_node(graph: &mut Graph, level: usize) -> Result<(), HnswError> {
+    graph.insert_first(NodeContext {
+        node: 0,
+        level,
+        sequence: 0,
+    })
 }
 
-fn attach_test_node(graph: &mut Graph, node: usize, level: usize, sequence: u64) {
-    graph
-        .attach_node(NodeContext {
-            node,
-            level,
-            sequence,
-        })
-        .expect("attach node");
+fn attach_test_node(
+    graph: &mut Graph,
+    node: usize,
+    level: usize,
+    sequence: u64,
+) -> Result<(), HnswError> {
+    graph.attach_node(NodeContext {
+        node,
+        level,
+        sequence,
+    })
 }
 
 fn assert_bidirectional_edge(graph: &Graph, node_a: usize, node_b: usize, level: usize) {
@@ -141,10 +147,10 @@ fn commit_inlines_reciprocity(
 ) -> Result<(), HnswError> {
     let params = HnswParams::new(max_connections, 4)?;
     let entry_level = new_node_level.max(seed_edge_level);
-    let mut graph = setup_basic_graph(max_connections, 4, 4);
-    insert_entry_node(&mut graph, entry_level);
+    let mut graph = setup_basic_graph(max_connections, 4, 4)?;
+    insert_entry_node(&mut graph, entry_level)?;
 
-    attach_test_node(&mut graph, 1, 0, 1);
+    attach_test_node(&mut graph, 1, 0, 1)?;
 
     add_edge_if_missing(&mut graph, 0, 1, seed_edge_level);
 
@@ -205,9 +211,9 @@ fn commit_inlines_reciprocity(
 
 #[test]
 fn enforce_bidirectional_all_adds_upper_layer_backlink() {
-    let mut graph = setup_basic_graph(2, 4, 2);
-    insert_entry_node(&mut graph, 1);
-    attach_test_node(&mut graph, 1, 1, 1);
+    let mut graph = setup_basic_graph(2, 4, 2).expect("params should be valid in tests");
+    insert_entry_node(&mut graph, 1).expect("insert entry");
+    attach_test_node(&mut graph, 1, 1, 1).expect("attach node");
 
     add_edge_if_missing(&mut graph, 0, 1, 1);
 
@@ -218,9 +224,9 @@ fn enforce_bidirectional_all_adds_upper_layer_backlink() {
 
 #[test]
 fn enforce_bidirectional_all_removes_invalid_upper_edge() {
-    let mut graph = setup_basic_graph(2, 4, 2);
-    insert_entry_node(&mut graph, 1);
-    attach_test_node(&mut graph, 1, 0, 1);
+    let mut graph = setup_basic_graph(2, 4, 2).expect("params should be valid in tests");
+    insert_entry_node(&mut graph, 1).expect("insert entry");
+    attach_test_node(&mut graph, 1, 0, 1).expect("attach node");
 
     // One-way edge exists at level 1, but target only has level 0.
     add_edge_if_missing(&mut graph, 0, 1, 1);
@@ -237,7 +243,7 @@ fn enforce_bidirectional_all_removes_invalid_upper_edge() {
 fn trimming_eviction_restores_reciprocity(
     #[case] trimmed_neighbours: Vec<usize>,
     #[case] max_connections: usize,
-) -> Result<(), HnswError> {
+) -> Result<(), Box<dyn Error>> {
     assert!(
         !trimmed_neighbours.is_empty(),
         "trimmed_neighbours must be non-empty to exercise eviction fallback",
@@ -257,11 +263,11 @@ fn trimming_eviction_restores_reciprocity(
 
     let mut graph =
         build_trimming_test_graph(&params, &trimmed_neighbours, reserve_id, new_node_id)?;
-    setup_reciprocal_edges_with_reserve(&mut graph, &trimmed_neighbours, evicted, reserve_id);
+    setup_reciprocal_edges_with_reserve(&mut graph, &trimmed_neighbours, evicted, reserve_id)?;
 
     apply_insertion_with_trim(&mut graph, &params, new_node_id, trimmed_neighbours.clone())?;
 
-    verify_post_trim_reciprocity(&graph, &params, new_node_id, evicted);
+    verify_post_trim_reciprocity(&graph, &params, new_node_id, evicted)?;
 
     Ok(())
 }

--- a/chutoro-core/src/hnsw/insert/executor/tests/mod.rs
+++ b/chutoro-core/src/hnsw/insert/executor/tests/mod.rs
@@ -261,8 +261,7 @@ fn trimming_eviction_restores_reciprocity(
         .last()
         .expect("trimmed_neighbours asserted as non-empty");
 
-    let mut graph =
-        build_trimming_test_graph(&params, &trimmed_neighbours, reserve_id, new_node_id)?;
+    let mut graph = build_trimming_test_graph(&params, &trimmed_neighbours, reserve_id)?;
     setup_reciprocal_edges_with_reserve(&mut graph, &trimmed_neighbours, evicted, reserve_id)?;
 
     apply_insertion_with_trim(&mut graph, &params, new_node_id, trimmed_neighbours.clone())?;

--- a/chutoro-core/src/hnsw/insert/executor/tests/trimming_fixtures.rs
+++ b/chutoro-core/src/hnsw/insert/executor/tests/trimming_fixtures.rs
@@ -4,6 +4,8 @@
 //! exercise the insertion executor's trimming and reciprocity restoration
 //! logic.
 
+use std::error::Error;
+
 use super::*;
 use crate::hnsw::{
     error::HnswError,
@@ -17,7 +19,7 @@ pub(super) fn apply_insertion_with_trim(
     params: &HnswParams,
     new_node_id: usize,
     trimmed_neighbours: Vec<usize>,
-) -> Result<(), HnswError> {
+) -> Result<(), Box<dyn Error>> {
     let reserve_id = new_node_id.saturating_add(1);
     let mut executor = InsertionExecutor::new(graph);
     let plan = InsertionPlan {
@@ -44,7 +46,7 @@ pub(super) fn apply_insertion_with_trim(
         1,
         "only the entry node should require trim"
     );
-    let job = trim_jobs.into_iter().next().expect("trim job expected");
+    let job = trim_jobs.into_iter().next().ok_or("trim job expected")?;
     assert_eq!(job.node, 0, "trim must target the entry node");
     let trim_result = TrimResult {
         node: job.node,
@@ -52,7 +54,7 @@ pub(super) fn apply_insertion_with_trim(
         neighbours: trimmed_neighbours,
     };
 
-    executor.commit(prepared, vec![trim_result])
+    Ok(executor.commit(prepared, vec![trim_result])?)
 }
 
 pub(super) fn verify_post_trim_reciprocity(
@@ -60,9 +62,9 @@ pub(super) fn verify_post_trim_reciprocity(
     params: &HnswParams,
     new_node_id: usize,
     evicted: usize,
-) {
+) -> Result<(), Box<dyn Error>> {
     let connection_limit = connection_limit_for_level(0, params.max_connections());
-    let entry = graph.node(0).expect("entry node available");
+    let entry = graph.node(0).ok_or("entry node available")?;
     let entry_neighbours = entry.neighbours(0);
     assert!(
         entry_neighbours.contains(&new_node_id),
@@ -79,7 +81,7 @@ pub(super) fn verify_post_trim_reciprocity(
 
     let new_node = graph
         .node(new_node_id)
-        .expect("new node must be attached after commit");
+        .ok_or("new node must be attached after commit")?;
     assert!(
         new_node.neighbours(0).contains(&0),
         "new node should have a reciprocal edge to the entry node",
@@ -91,6 +93,7 @@ pub(super) fn verify_post_trim_reciprocity(
             "forward edge from evicted neighbour should be removed",
         );
     }
+    Ok(())
 }
 
 pub(super) fn build_trimming_test_graph(
@@ -98,7 +101,7 @@ pub(super) fn build_trimming_test_graph(
     trimmed_neighbours: &[usize],
     reserve_id: usize,
     new_node_id: usize,
-) -> Result<Graph, HnswError> {
+) -> Result<Graph, Box<dyn Error>> {
     let capacity = reserve_id.saturating_add(1);
     let mut graph = Graph::with_capacity(params.clone(), capacity);
     graph.insert_first(NodeContext {
@@ -114,7 +117,7 @@ pub(super) fn build_trimming_test_graph(
         sequence: (trimmed_neighbours.len() + 1) as u64,
     })?;
 
-    set_entry_neighbours(&mut graph, trimmed_neighbours);
+    set_entry_neighbours(&mut graph, trimmed_neighbours)?;
 
     // new_node_id reserved for the insertion under test.
     let _ = new_node_id;
@@ -142,8 +145,8 @@ pub(super) fn setup_reciprocal_edges_with_reserve(
     trimmed_neighbours: &[usize],
     evicted: usize,
     reserve_id: usize,
-) {
-    set_entry_neighbours(graph, trimmed_neighbours);
+) -> Result<(), Box<dyn Error>> {
+    set_entry_neighbours(graph, trimmed_neighbours)?;
 
     for &neighbour in trimmed_neighbours {
         link_if_absent(graph, neighbour, 0);
@@ -151,12 +154,14 @@ pub(super) fn setup_reciprocal_edges_with_reserve(
 
     link_if_absent(graph, evicted, reserve_id);
     link_if_absent(graph, reserve_id, evicted);
+    Ok(())
 }
 
-fn set_entry_neighbours(graph: &mut Graph, neighbours: &[usize]) {
-    let entry_neighbours = graph.node_mut(0).expect("entry present").neighbours_mut(0);
+fn set_entry_neighbours(graph: &mut Graph, neighbours: &[usize]) -> Result<(), Box<dyn Error>> {
+    let entry_neighbours = graph.node_mut(0).ok_or("entry present")?.neighbours_mut(0);
     entry_neighbours.clear();
     entry_neighbours.extend(neighbours.iter().copied());
+    Ok(())
 }
 
 fn link_if_absent(graph: &mut Graph, origin: usize, target: usize) {

--- a/chutoro-core/src/hnsw/insert/executor/tests/trimming_fixtures.rs
+++ b/chutoro-core/src/hnsw/insert/executor/tests/trimming_fixtures.rs
@@ -4,8 +4,6 @@
 //! exercise the insertion executor's trimming and reciprocity restoration
 //! logic.
 
-use std::error::Error;
-
 use super::*;
 use crate::hnsw::{
     error::HnswError,
@@ -14,12 +12,35 @@ use crate::hnsw::{
     types::{InsertionPlan, LayerPlan, Neighbour},
 };
 
+/// Failure modes of the trimming fixtures.
+///
+/// Keeps the underlying [`HnswError`] intact while naming the fixture
+/// invariants that the helpers rely on, so a broken fixture is distinguishable
+/// from a genuine graph error.
+#[derive(Debug, thiserror::Error)]
+pub(super) enum TrimmingFixtureError {
+    /// A graph or executor operation failed.
+    #[error(transparent)]
+    Hnsw(#[from] HnswError),
+    /// The executor produced no trim job for the entry node.
+    #[error("trim job expected")]
+    MissingTrimJob,
+    /// A node the fixture requires was absent from the graph.
+    #[error("node {node} should be present: {reason}")]
+    MissingNode {
+        /// Identifier of the absent node.
+        node: usize,
+        /// Why the fixture expected the node to exist.
+        reason: &'static str,
+    },
+}
+
 pub(super) fn apply_insertion_with_trim(
     graph: &mut Graph,
     params: &HnswParams,
     new_node_id: usize,
     trimmed_neighbours: Vec<usize>,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), TrimmingFixtureError> {
     let reserve_id = new_node_id.saturating_add(1);
     let mut executor = InsertionExecutor::new(graph);
     let plan = InsertionPlan {
@@ -46,7 +67,10 @@ pub(super) fn apply_insertion_with_trim(
         1,
         "only the entry node should require trim"
     );
-    let job = trim_jobs.into_iter().next().ok_or("trim job expected")?;
+    let job = trim_jobs
+        .into_iter()
+        .next()
+        .ok_or(TrimmingFixtureError::MissingTrimJob)?;
     assert_eq!(job.node, 0, "trim must target the entry node");
     let trim_result = TrimResult {
         node: job.node,
@@ -62,9 +86,12 @@ pub(super) fn verify_post_trim_reciprocity(
     params: &HnswParams,
     new_node_id: usize,
     evicted: usize,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), TrimmingFixtureError> {
     let connection_limit = connection_limit_for_level(0, params.max_connections());
-    let entry = graph.node(0).ok_or("entry node available")?;
+    let entry = graph.node(0).ok_or(TrimmingFixtureError::MissingNode {
+        node: 0,
+        reason: "entry node available",
+    })?;
     let entry_neighbours = entry.neighbours(0);
     assert!(
         entry_neighbours.contains(&new_node_id),
@@ -81,7 +108,10 @@ pub(super) fn verify_post_trim_reciprocity(
 
     let new_node = graph
         .node(new_node_id)
-        .ok_or("new node must be attached after commit")?;
+        .ok_or(TrimmingFixtureError::MissingNode {
+            node: new_node_id,
+            reason: "new node must be attached after commit",
+        })?;
     assert!(
         new_node.neighbours(0).contains(&0),
         "new node should have a reciprocal edge to the entry node",
@@ -100,8 +130,7 @@ pub(super) fn build_trimming_test_graph(
     params: &HnswParams,
     trimmed_neighbours: &[usize],
     reserve_id: usize,
-    new_node_id: usize,
-) -> Result<Graph, Box<dyn Error>> {
+) -> Result<Graph, TrimmingFixtureError> {
     let capacity = reserve_id.saturating_add(1);
     let mut graph = Graph::with_capacity(params.clone(), capacity);
     graph.insert_first(NodeContext {
@@ -118,9 +147,6 @@ pub(super) fn build_trimming_test_graph(
     })?;
 
     set_entry_neighbours(&mut graph, trimmed_neighbours)?;
-
-    // new_node_id reserved for the insertion under test.
-    let _ = new_node_id;
 
     Ok(graph)
 }
@@ -145,7 +171,7 @@ pub(super) fn setup_reciprocal_edges_with_reserve(
     trimmed_neighbours: &[usize],
     evicted: usize,
     reserve_id: usize,
-) -> Result<(), Box<dyn Error>> {
+) -> Result<(), TrimmingFixtureError> {
     set_entry_neighbours(graph, trimmed_neighbours)?;
 
     for &neighbour in trimmed_neighbours {
@@ -157,8 +183,17 @@ pub(super) fn setup_reciprocal_edges_with_reserve(
     Ok(())
 }
 
-fn set_entry_neighbours(graph: &mut Graph, neighbours: &[usize]) -> Result<(), Box<dyn Error>> {
-    let entry_neighbours = graph.node_mut(0).ok_or("entry present")?.neighbours_mut(0);
+fn set_entry_neighbours(
+    graph: &mut Graph,
+    neighbours: &[usize],
+) -> Result<(), TrimmingFixtureError> {
+    let entry_neighbours = graph
+        .node_mut(0)
+        .ok_or(TrimmingFixtureError::MissingNode {
+            node: 0,
+            reason: "entry present",
+        })?
+        .neighbours_mut(0);
     entry_neighbours.clear();
     entry_neighbours.extend(neighbours.iter().copied());
     Ok(())

--- a/chutoro-core/src/hnsw/tests/cache.rs
+++ b/chutoro-core/src/hnsw/tests/cache.rs
@@ -1,6 +1,6 @@
 //! Tests for the concurrent distance cache supporting HNSW insertion.
 
-use std::{num::NonZeroUsize, thread, time::Duration};
+use std::{error::Error, num::NonZeroUsize, thread, time::Duration};
 
 use rstest::rstest;
 
@@ -9,15 +9,14 @@ use crate::{
     hnsw::distance_cache::{DistanceCache, DistanceCacheConfig, LookupOutcome},
 };
 
-fn cache_with_capacity(capacity: usize) -> DistanceCache {
-    let config =
-        DistanceCacheConfig::new(NonZeroUsize::new(capacity).expect("capacity must be non-zero"));
-    DistanceCache::new(config)
+fn cache_with_capacity(capacity: usize) -> Result<DistanceCache, Box<dyn Error>> {
+    let entries = NonZeroUsize::new(capacity).ok_or("capacity must be non-zero")?;
+    Ok(DistanceCache::new(DistanceCacheConfig::new(entries)))
 }
 
 #[rstest]
 fn caches_and_reuses_distances() {
-    let cache = cache_with_capacity(4);
+    let cache = cache_with_capacity(4).expect("capacity must be non-zero");
     let metric = MetricDescriptor::new("test-metric");
 
     let miss = match cache.begin_lookup(&metric, 0, 1) {
@@ -36,7 +35,7 @@ fn caches_and_reuses_distances() {
 
 #[rstest]
 fn lru_eviction_discards_oldest_entry() {
-    let cache = cache_with_capacity(2);
+    let cache = cache_with_capacity(2).expect("capacity must be non-zero");
     let metric = MetricDescriptor::new("lru");
 
     let miss_a = match cache.begin_lookup(&metric, 0, 1) {
@@ -104,7 +103,7 @@ fn ttl_expiry_forces_refresh() {
 /// normalization for symmetric distance metrics.
 #[rstest]
 fn normalizes_pair_order() {
-    let cache = cache_with_capacity(2);
+    let cache = cache_with_capacity(2).expect("capacity must be non-zero");
     let metric = MetricDescriptor::new("sym");
 
     let miss = match cache.begin_lookup(&metric, 7, 3) {
@@ -123,7 +122,7 @@ fn normalizes_pair_order() {
 
 #[rstest]
 fn rejects_non_finite_entries() {
-    let cache = cache_with_capacity(1);
+    let cache = cache_with_capacity(1).expect("capacity must be non-zero");
     let metric = MetricDescriptor::new("nan");
 
     let miss = match cache.begin_lookup(&metric, 2, 3) {
@@ -139,23 +138,27 @@ fn rejects_non_finite_entries() {
     ));
 }
 
-fn cache_config(max_entries: usize) -> DistanceCacheConfig {
-    DistanceCacheConfig::new(NonZeroUsize::new(max_entries).expect("non-zero"))
+fn cache_config(max_entries: usize) -> Result<DistanceCacheConfig, Box<dyn Error>> {
+    let entries = NonZeroUsize::new(max_entries).ok_or("non-zero")?;
+    Ok(DistanceCacheConfig::new(entries))
 }
 
 #[rstest]
-#[case(cache_config(64), cache_config(64), true)]
-#[case(cache_config(64), cache_config(128), false)]
-#[case(
-    cache_config(64),
-    cache_config(64).with_ttl(Some(Duration::from_secs(1))),
-    false
-)]
+#[case(64, 64, None, true)]
+#[case(64, 128, None, false)]
+#[case(64, 64, Some(Duration::from_secs(1)), false)]
 fn distance_cache_config_equality(
-    #[case] left_config: DistanceCacheConfig,
-    #[case] right_config: DistanceCacheConfig,
+    #[case] left_entries: usize,
+    #[case] right_entries: usize,
+    #[case] right_ttl: Option<Duration>,
     #[case] expected_equal: bool,
 ) {
+    let left_config = cache_config(left_entries).expect("non-zero");
+    let mut right_config = cache_config(right_entries).expect("non-zero");
+    if let Some(ttl) = right_ttl {
+        right_config = right_config.with_ttl(Some(ttl));
+    }
+
     if expected_equal {
         assert_eq!(left_config, right_config);
     } else {

--- a/chutoro-core/src/hnsw/tests/edge_harvest/mod.rs
+++ b/chutoro-core/src/hnsw/tests/edge_harvest/mod.rs
@@ -232,17 +232,11 @@ fn build_with_edges_single_threaded(
     max_connections: usize,
     ef_construction: usize,
     seed: u64,
-) -> (CpuHnsw, EdgeHarvest) {
+) -> Result<(CpuHnsw, EdgeHarvest), Box<dyn Error>> {
     let source = DummySource::new(data);
-    let params = HnswParams::new(max_connections, ef_construction)
-        .expect("params")
-        .with_rng_seed(seed);
-    let pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(1)
-        .build()
-        .expect("single-threaded Rayon pool");
-    pool.install(|| CpuHnsw::build_with_edges(&source, params))
-        .expect("build must succeed")
+    let params = HnswParams::new(max_connections, ef_construction)?.with_rng_seed(seed);
+    let pool = rayon::ThreadPoolBuilder::new().num_threads(1).build()?;
+    Ok(pool.install(|| CpuHnsw::build_with_edges(&source, params))?)
 }
 
 #[rstest]
@@ -267,9 +261,11 @@ fn build_with_edges_has_consistent_count(
     let data: Vec<f32> = (0..num_nodes).map(|i| i as f32).collect();
 
     let (index1, edges1) =
-        build_with_edges_single_threaded(data.clone(), max_connections, ef_construction, seed);
+        build_with_edges_single_threaded(data.clone(), max_connections, ef_construction, seed)
+            .expect("build must succeed");
     let (index2, edges2) =
-        build_with_edges_single_threaded(data, max_connections, ef_construction, seed);
+        build_with_edges_single_threaded(data, max_connections, ef_construction, seed)
+            .expect("build must succeed");
 
     assert_eq!(index1.len(), index2.len(), "index sizes must match");
     assert_eq!(

--- a/chutoro-core/src/hnsw/tests/property/edge_harvest_property.rs
+++ b/chutoro-core/src/hnsw/tests/property/edge_harvest_property.rs
@@ -202,12 +202,13 @@ mod tests {
     /// Builds a dedicated Rayon thread pool with EDGE_HARVEST_TEST_RAYON_THREADS
     /// threads and runs the provided closure on it to limit edge-harvest test
     /// concurrency for improved stability. Test-only helper.
-    fn with_edge_harvest_pool<T: Send>(f: impl FnOnce() -> T + Send) -> T {
+    fn with_edge_harvest_pool<T: Send>(
+        f: impl FnOnce() -> T + Send,
+    ) -> Result<T, rayon::ThreadPoolBuildError> {
         let pool = ThreadPoolBuilder::new()
             .num_threads(EDGE_HARVEST_TEST_RAYON_THREADS)
-            .build()
-            .expect("edge harvest test pool should build");
-        pool.install(f)
+            .build()?;
+        Ok(pool.install(f))
     }
 
     fn make_fixture(vector_count: usize, seed: u64) -> HnswFixture {
@@ -243,7 +244,8 @@ mod tests {
         with_edge_harvest_pool(|| {
             run_edge_harvest_determinism_property(fixture, plan)
                 .expect("determinism property must hold");
-        });
+        })
+        .expect("edge harvest test pool should build");
     }
 
     #[rstest]
@@ -256,7 +258,8 @@ mod tests {
         let fixture = make_fixture(vector_count, seed);
         with_edge_harvest_pool(|| {
             run_edge_harvest_validity_property(fixture).expect("validity property must hold");
-        });
+        })
+        .expect("edge harvest test pool should build");
     }
 
     #[rstest]
@@ -268,7 +271,8 @@ mod tests {
         let fixture = make_fixture(vector_count, seed);
         with_edge_harvest_pool(|| {
             run_edge_harvest_coverage_property(fixture).expect("coverage property must hold");
-        });
+        })
+        .expect("edge harvest test pool should build");
     }
 
     #[rstest]
@@ -320,7 +324,8 @@ mod tests {
             run_edge_harvest_coverage_property(fixture.clone()).expect("coverage must hold");
             run_edge_harvest_determinism_property(fixture, EdgeHarvestPlan::new(2))
                 .expect("determinism must hold");
-        });
+        })
+        .expect("edge harvest test pool should build");
     }
 
     #[rstest]
@@ -333,7 +338,8 @@ mod tests {
                 .expect("determinism with 2 nodes");
             run_edge_harvest_validity_property(fixture.clone()).expect("validity with 2 nodes");
             run_edge_harvest_coverage_property(fixture).expect("coverage with 2 nodes");
-        });
+        })
+        .expect("edge harvest test pool should build");
     }
 
     #[rstest]
@@ -343,7 +349,8 @@ mod tests {
         let source = fixture.into_source().expect("source");
 
         let (_, edges) =
-            with_edge_harvest_pool(|| CpuHnsw::build_with_edges(&source, params).expect("build"));
+            with_edge_harvest_pool(|| CpuHnsw::build_with_edges(&source, params).expect("build"))
+                .expect("edge harvest test pool should build");
 
         // Verify edges are sorted: primary key is sequence, secondary is natural Ord.
         //

--- a/chutoro-core/src/hnsw/tests/property/fixtures/mod.rs
+++ b/chutoro-core/src/hnsw/tests/property/fixtures/mod.rs
@@ -8,9 +8,8 @@ use serde::Deserialize;
 struct BootstrapVectors(Vec<Vec<f32>>);
 
 /// Loads bootstrap uniform vectors from the embedded fixture file.
-pub(super) fn load_bootstrap_uniform_vectors_from_fixture() -> Vec<Vec<f32>> {
+pub(super) fn load_bootstrap_uniform_vectors_from_fixture()
+-> Result<Vec<Vec<f32>>, serde_json::Error> {
     const RAW: &str = include_str!("bootstrap_uniform_vectors.json");
-    serde_json::from_str::<BootstrapVectors>(RAW)
-        .expect("bootstrap uniform vectors fixture should parse")
-        .0
+    Ok(serde_json::from_str::<BootstrapVectors>(RAW)?.0)
 }

--- a/chutoro-core/src/hnsw/tests/property/search_property.rs
+++ b/chutoro-core/src/hnsw/tests/property/search_property.rs
@@ -48,7 +48,8 @@ pub(super) fn run_search_correctness_property(
     let fanout_cap = fixture.params.max_connections.max(2);
     let max_k = len.min(16).min(fanout_cap);
     let k = ((usize::from(k_hint) % max_k).max(1)).min(len);
-    let ef = NonZeroUsize::new(len.max(k * 2).max(16)).expect("ef must be non-zero");
+    let ef = NonZeroUsize::new(len.max(k * 2).max(16))
+        .ok_or_else(|| TestCaseError::fail("ef must be non-zero"))?;
 
     let index = CpuHnsw::build(&source, params)
         .map_err(|err| TestCaseError::fail(format!("build failed: {err}")))?;

--- a/chutoro-core/src/hnsw/tests/property/test_runner_support.rs
+++ b/chutoro-core/src/hnsw/tests/property/test_runner_support.rs
@@ -1,6 +1,7 @@
 //! Shared proptest runner and coverage-budget helpers for HNSW property tests.
 
 mod budget_selection;
+mod budget_types;
 mod runner_wrappers;
 
 pub(super) use budget_selection::{

--- a/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_selection.rs
+++ b/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_selection.rs
@@ -175,6 +175,14 @@ pub(crate) fn select_mutation_cases(
     select_mutation_cases_for_fork(job, configured, false)
 }
 
+/// Reports whether a forked run keeps its configured mutation budget uncapped.
+///
+/// Forked scheduled runs opt into deeper coverage, so the `MAX_MUTATION_CASES`
+/// cap that protects pull request runs does not apply to them.
+fn should_preserve_forked_budget(job: JobKind, is_forked: bool) -> bool {
+    is_forked && !job.is_coverage()
+}
+
 /// Selects mutation case count while preserving forked deep-run budgets.
 ///
 /// # Errors
@@ -182,15 +190,15 @@ pub(crate) fn select_mutation_cases(
 pub(crate) fn select_mutation_cases_for_fork(
     job: JobKind,
     configured: TestCases,
-    fork: bool,
+    is_forked: bool,
 ) -> Result<TestCases, InvalidTestCasesError> {
     if job.is_coverage() {
-        TestCases::try_new(COVERAGE_MUTATION_CASES)
-    } else if fork {
-        Ok(configured)
-    } else {
-        TestCases::try_new(configured.get().min(MAX_MUTATION_CASES))
+        return TestCases::try_new(COVERAGE_MUTATION_CASES);
     }
+    if should_preserve_forked_budget(job, is_forked) {
+        return Ok(configured);
+    }
+    TestCases::try_new(configured.get().min(MAX_MUTATION_CASES))
 }
 
 /// Returns the number of mutation test cases, auto-detecting the job kind.

--- a/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_selection.rs
+++ b/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_selection.rs
@@ -4,145 +4,9 @@ use chutoro_test_support::ci::property_test_profile::ProptestRunProfile;
 
 use crate::hnsw::tests::support::is_coverage_job;
 
-/// Number of test cases to execute in a property test run.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct TestCases(u32);
-
-/// Error returned when test case count is invalid.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct InvalidTestCasesError;
-
-impl std::fmt::Display for InvalidTestCasesError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "test cases must be > 0")
-    }
-}
-
-impl std::error::Error for InvalidTestCasesError {}
-
-impl TestCases {
-    /// Creates a new TestCases value, returning an error if invalid.
-    ///
-    /// # Errors
-    /// Returns `InvalidTestCasesError` if `cases` is zero.
-    pub(crate) fn try_new(cases: u32) -> Result<Self, InvalidTestCasesError> {
-        if cases > 0 {
-            Ok(Self(cases))
-        } else {
-            Err(InvalidTestCasesError)
-        }
-    }
-
-    /// Creates a new TestCases value.
-    ///
-    /// # Panics
-    /// Panics if `cases` is zero (at least one test case is required).
-    pub(crate) fn new(cases: u32) -> Self {
-        Self::try_new(cases).expect("test cases must be > 0")
-    }
-
-    /// Returns the number of test cases.
-    pub(crate) fn get(self) -> u32 {
-        self.0
-    }
-}
-
-impl From<TestCases> for u32 {
-    fn from(cases: TestCases) -> u32 {
-        cases.0
-    }
-}
-
-/// Maximum number of shrinking iterations to attempt when minimizing a failing test case.
-///
-/// A value of 0 disables shrinking entirely. In practice, positive values are used to enable
-/// counterexample minimization.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct ShrinkIterations(u32);
-
-impl ShrinkIterations {
-    /// Creates a new ShrinkIterations value.
-    ///
-    /// Setting `iterations` to 0 disables shrinking.
-    pub(crate) fn new(iterations: u32) -> Self {
-        Self(iterations)
-    }
-
-    /// Returns the number of shrink iterations.
-    ///
-    /// A return value of 0 means shrinking is disabled.
-    pub(crate) fn get(self) -> u32 {
-        self.0
-    }
-}
-
-impl From<ShrinkIterations> for u32 {
-    fn from(iters: ShrinkIterations) -> u32 {
-        iters.0
-    }
-}
-
-/// Stack size in bytes for property test runner threads.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct StackSize(usize);
-
-/// Error returned when stack size is below the minimum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct InvalidStackSizeError {
-    provided: usize,
-    minimum: usize,
-}
-
-impl std::fmt::Display for InvalidStackSizeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "stack size must be >= {} bytes, got {}",
-            self.minimum, self.provided
-        )
-    }
-}
-
-impl std::error::Error for InvalidStackSizeError {}
-
-impl StackSize {
-    /// Minimum safe stack size (1 MiB).
-    const MIN_STACK_SIZE: usize = 1024 * 1024;
-
-    /// Creates a new StackSize value, returning an error if below minimum.
-    ///
-    /// # Errors
-    /// Returns `InvalidStackSizeError` if `size` is below `MIN_STACK_SIZE`.
-    pub(crate) fn try_new(size: usize) -> Result<Self, InvalidStackSizeError> {
-        if size >= Self::MIN_STACK_SIZE {
-            Ok(Self(size))
-        } else {
-            Err(InvalidStackSizeError {
-                provided: size,
-                minimum: Self::MIN_STACK_SIZE,
-            })
-        }
-    }
-
-    /// Creates a new StackSize value.
-    ///
-    /// # Panics
-    /// Panics if `size` is below `MIN_STACK_SIZE`.
-    pub(crate) fn new(size: usize) -> Self {
-        Self::try_new(size).expect("stack size must be >= minimum")
-    }
-
-    /// Returns the stack size in bytes.
-    pub(crate) fn get(self) -> usize {
-        self.0
-    }
-}
-
-impl From<StackSize> for usize {
-    fn from(size: StackSize) -> usize {
-        size.0
-    }
-}
+pub(crate) use super::budget_types::{
+    InvalidTestCasesError, ShrinkIterations, StackSize, TestCases,
+};
 
 /// Whether the current job runs under coverage instrumentation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -218,11 +82,15 @@ const DEFAULT_SEARCH_MAX_SHRINK_ITERS: u32 = 1024;
 /// Default search case count when no profile override is configured.
 const DEFAULT_SEARCH_CASES: u32 = 64;
 
-fn select_cases(job: JobKind, configured: TestCases, coverage_cases: u32) -> TestCases {
+fn select_cases(
+    job: JobKind,
+    configured: TestCases,
+    coverage_cases: u32,
+) -> Result<TestCases, InvalidTestCasesError> {
     if job.is_coverage() {
-        TestCases::new(coverage_cases)
+        TestCases::try_new(coverage_cases)
     } else {
-        configured
+        Ok(configured)
     }
 }
 
@@ -238,19 +106,25 @@ fn select_shrink_iterations(
     }
 }
 
-fn configured_cases(default_cases: u32) -> TestCases {
-    TestCases::new(property_run_profile(default_cases).cases())
+fn configured_cases(default_cases: u32) -> Result<TestCases, InvalidTestCasesError> {
+    TestCases::try_new(property_run_profile(default_cases).cases())
 }
 
 /// Selects the number of idempotency test cases based on job kind.
 ///
 /// Returns capped configured cases for non-coverage jobs, or a reduced count
 /// (`COVERAGE_IDEMPOTENCY_CASES`) for coverage-instrumented runs.
-pub(crate) fn select_idempotency_cases(job: JobKind, configured: TestCases) -> TestCases {
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the selected case count is zero.
+pub(crate) fn select_idempotency_cases(
+    job: JobKind,
+    configured: TestCases,
+) -> Result<TestCases, InvalidTestCasesError> {
     if job.is_coverage() {
-        TestCases::new(COVERAGE_IDEMPOTENCY_CASES)
+        TestCases::try_new(COVERAGE_IDEMPOTENCY_CASES)
     } else {
-        TestCases::new(configured.get().min(MAX_IDEMPOTENCY_CASES))
+        TestCases::try_new(configured.get().min(MAX_IDEMPOTENCY_CASES))
     }
 }
 
@@ -258,10 +132,13 @@ pub(crate) fn select_idempotency_cases(job: JobKind, configured: TestCases) -> T
 ///
 /// Calls `select_idempotency_cases` with the detected `JobKind` and
 /// the default idempotency case count from the property test profile.
-pub(crate) fn idempotency_cases() -> TestCases {
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the configured case count is zero.
+pub(crate) fn idempotency_cases() -> Result<TestCases, InvalidTestCasesError> {
     select_idempotency_cases(
         JobKind::detect(),
-        configured_cases(DEFAULT_IDEMPOTENCY_CASES),
+        configured_cases(DEFAULT_IDEMPOTENCY_CASES)?,
     )
 }
 
@@ -288,22 +165,31 @@ pub(crate) fn idempotency_shrink_iters() -> ShrinkIterations {
 ///
 /// Returns capped configured cases for non-forked non-coverage jobs, or a
 /// reduced count (`COVERAGE_MUTATION_CASES`) for coverage-instrumented runs.
-pub(crate) fn select_mutation_cases(job: JobKind, configured: TestCases) -> TestCases {
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the selected case count is zero.
+pub(crate) fn select_mutation_cases(
+    job: JobKind,
+    configured: TestCases,
+) -> Result<TestCases, InvalidTestCasesError> {
     select_mutation_cases_for_fork(job, configured, false)
 }
 
 /// Selects mutation case count while preserving forked deep-run budgets.
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the selected case count is zero.
 pub(crate) fn select_mutation_cases_for_fork(
     job: JobKind,
     configured: TestCases,
     fork: bool,
-) -> TestCases {
+) -> Result<TestCases, InvalidTestCasesError> {
     if job.is_coverage() {
-        TestCases::new(COVERAGE_MUTATION_CASES)
+        TestCases::try_new(COVERAGE_MUTATION_CASES)
     } else if fork {
-        configured
+        Ok(configured)
     } else {
-        TestCases::new(configured.get().min(MAX_MUTATION_CASES))
+        TestCases::try_new(configured.get().min(MAX_MUTATION_CASES))
     }
 }
 
@@ -311,11 +197,14 @@ pub(crate) fn select_mutation_cases_for_fork(
 ///
 /// Calls `select_mutation_cases_for_fork` with the detected `JobKind` and the
 /// mutation case count from the property test profile.
-pub(crate) fn mutation_cases() -> TestCases {
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the configured case count is zero.
+pub(crate) fn mutation_cases() -> Result<TestCases, InvalidTestCasesError> {
     let profile = property_run_profile(DEFAULT_MUTATION_CASES);
     select_mutation_cases_for_fork(
         JobKind::detect(),
-        TestCases::new(profile.cases()),
+        TestCases::try_new(profile.cases())?,
         profile.fork(),
     )
 }
@@ -343,7 +232,13 @@ pub(crate) fn mutation_shrink_iters() -> ShrinkIterations {
 ///
 /// Returns the configured cases for non-coverage jobs, or a reduced count
 /// (`COVERAGE_SEARCH_CASES`) for coverage-instrumented runs.
-pub(crate) fn select_search_cases(job: JobKind, configured: TestCases) -> TestCases {
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the selected case count is zero.
+pub(crate) fn select_search_cases(
+    job: JobKind,
+    configured: TestCases,
+) -> Result<TestCases, InvalidTestCasesError> {
     select_cases(job, configured, COVERAGE_SEARCH_CASES)
 }
 
@@ -351,8 +246,11 @@ pub(crate) fn select_search_cases(job: JobKind, configured: TestCases) -> TestCa
 ///
 /// Calls `select_search_cases` with the detected `JobKind` and
 /// the default search case count from the property test profile.
-pub(crate) fn search_cases() -> TestCases {
-    select_search_cases(JobKind::detect(), configured_cases(DEFAULT_SEARCH_CASES))
+///
+/// # Errors
+/// Returns `InvalidTestCasesError` if the configured case count is zero.
+pub(crate) fn search_cases() -> Result<TestCases, InvalidTestCasesError> {
+    select_search_cases(JobKind::detect(), configured_cases(DEFAULT_SEARCH_CASES)?)
 }
 
 /// Selects the maximum shrink iterations for search property tests based on job kind.

--- a/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_types.rs
+++ b/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_types.rs
@@ -1,0 +1,128 @@
+//! Value types for property-test budget selection.
+//!
+//! These newtypes carry the validated case counts, shrink budgets, and
+//! runner stack sizes consumed by `budget_selection`.
+
+/// Number of test cases to execute in a property test run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TestCases(u32);
+
+/// Error returned when test case count is invalid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InvalidTestCasesError;
+
+impl std::fmt::Display for InvalidTestCasesError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "test cases must be > 0")
+    }
+}
+
+impl std::error::Error for InvalidTestCasesError {}
+
+impl TestCases {
+    /// Creates a new TestCases value, returning an error if invalid.
+    ///
+    /// # Errors
+    /// Returns `InvalidTestCasesError` if `cases` is zero.
+    pub(crate) fn try_new(cases: u32) -> Result<Self, InvalidTestCasesError> {
+        if cases > 0 {
+            Ok(Self(cases))
+        } else {
+            Err(InvalidTestCasesError)
+        }
+    }
+
+    /// Returns the number of test cases.
+    pub(crate) fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<TestCases> for u32 {
+    fn from(cases: TestCases) -> u32 {
+        cases.0
+    }
+}
+
+/// Maximum number of shrinking iterations to attempt when minimizing a failing test case.
+///
+/// A value of 0 disables shrinking entirely. In practice, positive values are used to enable
+/// counterexample minimization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ShrinkIterations(u32);
+
+impl ShrinkIterations {
+    /// Creates a new ShrinkIterations value.
+    ///
+    /// Setting `iterations` to 0 disables shrinking.
+    pub(crate) fn new(iterations: u32) -> Self {
+        Self(iterations)
+    }
+
+    /// Returns the number of shrink iterations.
+    ///
+    /// A return value of 0 means shrinking is disabled.
+    pub(crate) fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<ShrinkIterations> for u32 {
+    fn from(iters: ShrinkIterations) -> u32 {
+        iters.0
+    }
+}
+
+/// Stack size in bytes for property test runner threads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct StackSize(usize);
+
+/// Error returned when stack size is below the minimum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InvalidStackSizeError {
+    provided: usize,
+    minimum: usize,
+}
+
+impl std::fmt::Display for InvalidStackSizeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "stack size must be >= {} bytes, got {}",
+            self.minimum, self.provided
+        )
+    }
+}
+
+impl std::error::Error for InvalidStackSizeError {}
+
+impl StackSize {
+    /// Minimum safe stack size (1 MiB).
+    const MIN_STACK_SIZE: usize = 1024 * 1024;
+
+    /// Creates a new StackSize value, returning an error if below minimum.
+    ///
+    /// # Errors
+    /// Returns `InvalidStackSizeError` if `size` is below `MIN_STACK_SIZE`.
+    pub(crate) fn try_new(size: usize) -> Result<Self, InvalidStackSizeError> {
+        if size >= Self::MIN_STACK_SIZE {
+            Ok(Self(size))
+        } else {
+            Err(InvalidStackSizeError {
+                provided: size,
+                minimum: Self::MIN_STACK_SIZE,
+            })
+        }
+    }
+
+    /// Returns the stack size in bytes.
+    pub(crate) fn get(self) -> usize {
+        self.0
+    }
+}
+
+impl From<StackSize> for usize {
+    fn from(size: StackSize) -> usize {
+        size.0
+    }
+}

--- a/chutoro-core/src/hnsw/tests/property/test_runner_support/runner_wrappers.rs
+++ b/chutoro-core/src/hnsw/tests/property/test_runner_support/runner_wrappers.rs
@@ -192,9 +192,9 @@ struct PropertyRunnerConfig {
 ///
 /// ```rust,ignore
 /// let config = idempotency_runner_config(
-///     TestCases::new(25000),
+///     TestCases::try_new(25000).expect("test cases must be > 0"),
 ///     ShrinkIterations::new(1024),
-///     StackSize::new(96 * 1024 * 1024),
+///     StackSize::try_new(96 * 1024 * 1024).expect("stack size must be >= minimum"),
 /// );
 ///
 /// assert!(!config.fork);
@@ -253,9 +253,10 @@ mod tests {
 
     #[test]
     fn idempotency_runner_config_disables_forking() {
-        let cases = TestCases::new(25000);
+        let cases = TestCases::try_new(25000).expect("test cases must be > 0");
         let max_shrink_iters = ShrinkIterations::new(1024);
-        let stack_size = StackSize::new(96 * 1024 * 1024);
+        let stack_size =
+            StackSize::try_new(96 * 1024 * 1024).expect("stack size must be >= minimum");
 
         let config = idempotency_runner_config(cases, max_shrink_iters, stack_size);
 

--- a/chutoro-core/src/hnsw/tests/property/tests.rs
+++ b/chutoro-core/src/hnsw/tests/property/tests.rs
@@ -186,23 +186,26 @@ proptest! {
 #[ignore]
 fn hnsw_mutations_preserve_invariants_proptest_stress() -> TestCaseResult {
     run_mutation_test(
-        TestCases::new(640),
+        TestCases::try_new(640).expect("test cases must be > 0"),
         ShrinkIterations::new(4096),
-        StackSize::new(32 * 1024 * 1024),
+        StackSize::try_new(32 * 1024 * 1024).expect("stack size must be >= minimum"),
     )
 }
 
 #[test]
 fn hnsw_search_matches_brute_force_proptest() -> TestCaseResult {
-    run_search_test(search_cases(), search_shrink_iters())
+    run_search_test(
+        search_cases().expect("test cases must be > 0"),
+        search_shrink_iters(),
+    )
 }
 
 #[test]
 fn hnsw_idempotency_preserved_proptest() -> TestCaseResult {
     run_idempotency_test(
-        idempotency_cases(),
+        idempotency_cases().expect("test cases must be > 0"),
         idempotency_shrink_iters(),
-        StackSize::new(96 * 1024 * 1024),
+        StackSize::try_new(96 * 1024 * 1024).expect("stack size must be >= minimum"),
     )
 }
 
@@ -215,9 +218,10 @@ fn select_idempotency_cases_enforces_coverage_budget(
     #[case] configured_cases: u32,
     #[case] expected_cases: u32,
 ) {
+    let configured = TestCases::try_new(configured_cases).expect("test cases must be > 0");
     assert_eq!(
-        select_idempotency_cases(job, TestCases::new(configured_cases)),
-        TestCases::new(expected_cases)
+        select_idempotency_cases(job, configured),
+        TestCases::try_new(expected_cases)
     );
 }
 
@@ -243,9 +247,10 @@ fn select_mutation_cases_enforces_pr_budget(
     #[case] configured_cases: u32,
     #[case] expected_cases: u32,
 ) {
+    let configured = TestCases::try_new(configured_cases).expect("test cases must be > 0");
     assert_eq!(
-        select_mutation_cases(job, TestCases::new(configured_cases)),
-        TestCases::new(expected_cases)
+        select_mutation_cases(job, configured),
+        TestCases::try_new(expected_cases)
     );
 }
 
@@ -260,9 +265,10 @@ fn select_mutation_cases_preserves_forked_deep_run_budget(
     #[case] configured_cases: u32,
     #[case] expected_cases: u32,
 ) {
+    let configured = TestCases::try_new(configured_cases).expect("test cases must be > 0");
     assert_eq!(
-        select_mutation_cases_for_fork(job, TestCases::new(configured_cases), fork),
-        TestCases::new(expected_cases)
+        select_mutation_cases_for_fork(job, configured, fork),
+        TestCases::try_new(expected_cases)
     );
 }
 
@@ -288,9 +294,10 @@ fn select_search_cases_enforces_coverage_budget(
     #[case] configured_cases: u32,
     #[case] expected_cases: u32,
 ) {
+    let configured = TestCases::try_new(configured_cases).expect("test cases must be > 0");
     assert_eq!(
-        select_search_cases(job, TestCases::new(configured_cases)),
-        TestCases::new(expected_cases)
+        select_search_cases(job, configured),
+        TestCases::try_new(expected_cases)
     );
 }
 
@@ -310,9 +317,9 @@ fn select_search_shrink_iters_enforces_coverage_budget(
 #[test]
 fn hnsw_mutations_preserve_invariants_proptest() -> TestCaseResult {
     run_mutation_test(
-        mutation_cases(),
+        mutation_cases().expect("test cases must be > 0"),
         mutation_shrink_iters(),
-        StackSize::new(96 * 1024 * 1024),
+        StackSize::try_new(96 * 1024 * 1024).expect("stack size must be >= minimum"),
     )
 }
 
@@ -326,7 +333,8 @@ fn bootstrap_uniform_fixture_remains_reachable() {
         rng_seed: 0,
     };
     let params = seed.build().expect("params must be valid");
-    let vectors = bootstrap_uniform_vectors();
+    let vectors =
+        bootstrap_uniform_vectors().expect("bootstrap uniform vectors fixture should parse");
     let source =
         DenseVectorSource::new("uniform-bootstrap", vectors).expect("fixture must be valid");
     let len = source.len();
@@ -358,7 +366,7 @@ fn bootstrap_uniform_fixture_remains_reachable() {
         .expect("bootstrap should preserve reachability");
 }
 
-fn bootstrap_uniform_vectors() -> Vec<Vec<f32>> {
+fn bootstrap_uniform_vectors() -> Result<Vec<Vec<f32>>, serde_json::Error> {
     super::fixtures::load_bootstrap_uniform_vectors_from_fixture()
 }
 

--- a/chutoro-core/src/hnsw/tests/write_lock.rs
+++ b/chutoro-core/src/hnsw/tests/write_lock.rs
@@ -144,22 +144,20 @@ fn write_lock_source() -> WriteLockAssertingSource {
 }
 
 #[fixture]
-fn write_lock_params() -> HnswParams {
-    HnswParams::new(2, 4)
-        .expect("params must be valid")
-        .with_rng_seed(11)
+fn write_lock_params() -> Result<HnswParams, HnswError> {
+    Ok(HnswParams::new(2, 4)?.with_rng_seed(11))
 }
 
 #[fixture]
 fn built_write_lock_scenario(
     write_lock_source: WriteLockAssertingSource,
-    write_lock_params: HnswParams,
-) -> WriteLockScenario {
-    let index = CpuHnsw::build(&write_lock_source, write_lock_params).expect("build must succeed");
-    WriteLockScenario {
+    write_lock_params: Result<HnswParams, HnswError>,
+) -> Result<WriteLockScenario, HnswError> {
+    let index = CpuHnsw::build(&write_lock_source, write_lock_params?)?;
+    Ok(WriteLockScenario {
         source: write_lock_source,
         index,
-    }
+    })
 }
 
 fn write_lock_case_strategy() -> impl Strategy<Value = WriteLockPropertyCase> {
@@ -205,12 +203,10 @@ fn assert_write_lock_property(case: WriteLockPropertyCase) -> TestCaseResult {
     let index = build_generated_index(&source, params)
         .map_err(|error| TestCaseError::fail(format!("generated build failed: {error}")))?;
 
+    let search_ef = NonZeroUsize::new(case.search_ef)
+        .ok_or_else(|| TestCaseError::fail("generated ef must be non-zero"))?;
     index
-        .search(
-            &source,
-            case.query,
-            NonZeroUsize::new(case.search_ef).expect("generated ef must be non-zero"),
-        )
+        .search(&source, case.query, search_ef)
         .map_err(|error| TestCaseError::fail(format!("generated search failed: {error}")))?;
 
     prop_assert!(
@@ -235,9 +231,9 @@ fn build_generated_index(
 #[rstest]
 fn write_graph_marker_is_scoped_to_the_current_thread(
     _write_graph_marker_guard: WriteGraphMarkerGuard,
-    write_lock_params: HnswParams,
+    write_lock_params: Result<HnswParams, HnswError>,
 ) -> Result<(), HnswError> {
-    let index = CpuHnsw::with_capacity(write_lock_params, 2).expect("index should allocate");
+    let index = CpuHnsw::with_capacity(write_lock_params?, 2).expect("index should allocate");
     assert!(!CpuHnsw::current_thread_holds_write_graph_for_test());
     index.write_graph(|_graph| {
         assert!(CpuHnsw::current_thread_holds_write_graph_for_test());
@@ -250,19 +246,20 @@ fn write_graph_marker_is_scoped_to_the_current_thread(
 #[rstest]
 fn hnsw_scoring_does_not_run_inside_write_graph_scope(
     _write_graph_marker_guard: WriteGraphMarkerGuard,
-    built_write_lock_scenario: WriteLockScenario,
+    built_write_lock_scenario: Result<WriteLockScenario, HnswError>,
 ) {
-    built_write_lock_scenario
+    let scenario = built_write_lock_scenario.expect("build must succeed");
+    scenario
         .index
         .search(
-            &built_write_lock_scenario.source,
+            &scenario.source,
             1,
             NonZeroUsize::new(4).expect("ef must be non-zero"),
         )
         .expect("search must succeed");
 
     assert!(
-        built_write_lock_scenario.source.scoring_calls() > 0,
+        scenario.source.scoring_calls() > 0,
         "the guard should observe real HNSW scoring calls",
     );
 }
@@ -272,9 +269,10 @@ fn hnsw_scoring_does_not_run_inside_write_graph_scope(
 fn write_lock_scoring_guard_has_teeth(
     _write_graph_marker_guard: WriteGraphMarkerGuard,
     write_lock_source: WriteLockAssertingSource,
-    write_lock_params: HnswParams,
+    write_lock_params: Result<HnswParams, HnswError>,
 ) {
-    let index = CpuHnsw::with_capacity(write_lock_params, 2).expect("index should allocate");
+    let params = write_lock_params.expect("params must be valid");
+    let index = CpuHnsw::with_capacity(params, 2).expect("index should allocate");
     index
         .write_graph(|_graph| {
             let _distances = write_lock_source

--- a/chutoro-core/src/session/tests.rs
+++ b/chutoro-core/src/session/tests.rs
@@ -15,6 +15,7 @@ mod common;
 mod concurrency;
 mod core_distance;
 mod core_distance_errors;
+mod core_distance_support;
 #[cfg(feature = "metrics")]
 mod metrics;
 mod properties;

--- a/chutoro-core/src/session/tests/append.rs
+++ b/chutoro-core/src/session/tests/append.rs
@@ -14,7 +14,7 @@ use crate::{ChutoroBuilder, ChutoroError, DataSource, DataSourceErrorCode, HnswP
 
 #[rstest]
 fn append_empty_slice_is_noop(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
 
     session.append(&[]).expect("empty append must succeed");
 
@@ -25,7 +25,7 @@ fn append_empty_slice_is_noop(session_builder: ChutoroBuilder) {
 
 #[rstest]
 fn append_single_index_increases_point_count(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
 
     session.append(&[0]).expect("first append must succeed");
 
@@ -40,9 +40,11 @@ fn append_batch_accumulates_direct_harvested_edges(session_builder: ChutoroBuild
         .expect("HNSW params must be valid")
         .with_rng_seed(41);
     let (mut session, source) =
-        make_session(session_builder.with_hnsw_params(hnsw_params.clone()), 6);
+        make_session(session_builder.with_hnsw_params(hnsw_params.clone()), 6)
+            .expect("session must build");
     let indices = [0, 1, 2, 3];
-    let expected_edges = harvest_expected_edges(hnsw_params, source.as_ref(), &indices);
+    let expected_edges = harvest_expected_edges(hnsw_params, source.as_ref(), &indices)
+        .expect("direct harvest must succeed");
 
     session.append(&indices).expect("batch append must succeed");
 
@@ -55,7 +57,7 @@ fn append_batch_accumulates_direct_harvested_edges(session_builder: ChutoroBuild
 fn append_delegates_duplicate_rejection_to_hnsw(session_builder: ChutoroBuilder) {
     // Duplicate detection is delegated to CpuHnsw::insert_harvesting, which
     // returns HnswError::DuplicateIndex, mapped here to ChutoroError::CpuHnswFailure.
-    let (mut session, _) = make_session(session_builder, 2);
+    let (mut session, _) = make_session(session_builder, 2).expect("session must build");
 
     session.append(&[0]).expect("first append must succeed");
     let err = session
@@ -71,7 +73,7 @@ fn append_delegates_duplicate_rejection_to_hnsw(session_builder: ChutoroBuilder)
 
 #[rstest]
 fn append_rejects_out_of_bounds_index(session_builder: ChutoroBuilder) {
-    let (mut session, source) = make_session(session_builder, 2);
+    let (mut session, source) = make_session(session_builder, 2).expect("session must build");
 
     let err = session
         .append(&[source.len()])
@@ -98,10 +100,12 @@ fn append_failure_preserves_prior_successes(session_builder: ChutoroBuilder) {
         .expect("HNSW params must be valid")
         .with_rng_seed(41);
     let (mut session, source) =
-        make_session(session_builder.with_hnsw_params(hnsw_params.clone()), 4);
+        make_session(session_builder.with_hnsw_params(hnsw_params.clone()), 4)
+            .expect("session must build");
 
     // Build the expected edge set using the direct index as a baseline.
-    let expected_edges = harvest_expected_edges(hnsw_params, source.as_ref(), &[0, 1]);
+    let expected_edges = harvest_expected_edges(hnsw_params, source.as_ref(), &[0, 1])
+        .expect("direct harvest must succeed");
     // expected_edges is non-empty at this point because inserting index 1
     // into a graph that already contains index 0 harvests their mutual edge.
     assert!(
@@ -136,7 +140,7 @@ fn append_failure_preserves_prior_successes(session_builder: ChutoroBuilder) {
 
 #[rstest]
 fn append_does_not_publish_label_snapshot(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
 
     session.append(&[0, 1, 2]).expect("append must succeed");
 

--- a/chutoro-core/src/session/tests/common.rs
+++ b/chutoro-core/src/session/tests/common.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use rstest::fixture;
 
 use crate::{
-    CandidateEdge, ChutoroBuilder, ClusteringSession, CpuHnsw, DataSource, DataSourceError,
-    HnswParams, MetricDescriptor,
+    CandidateEdge, ChutoroBuilder, ChutoroError, ClusteringSession, CpuHnsw, DataSource,
+    DataSourceError, HnswError, HnswParams, MetricDescriptor,
 };
 
 #[derive(Clone, Debug)]
@@ -61,30 +61,27 @@ pub(super) fn session_builder() -> ChutoroBuilder {
     ChutoroBuilder::new()
 }
 
+pub(super) type SessionAndSource = (ClusteringSession<SessionTestSource>, Arc<SessionTestSource>);
+
 pub(super) fn make_session(
     builder: ChutoroBuilder,
     source_len: usize,
-) -> (ClusteringSession<SessionTestSource>, Arc<SessionTestSource>) {
+) -> Result<SessionAndSource, ChutoroError> {
     let source = Arc::new(SessionTestSource::with_len(source_len));
-    let session = builder
-        .build_session(Arc::clone(&source))
-        .expect("session must build");
-    (session, source)
+    let session = builder.build_session(Arc::clone(&source))?;
+    Ok((session, source))
 }
 
 pub(super) fn harvest_expected_edges(
     hnsw_params: HnswParams,
     source: &SessionTestSource,
     indices: &[usize],
-) -> Vec<CandidateEdge> {
-    let direct_index = CpuHnsw::with_capacity(hnsw_params, source.len().max(1))
-        .expect("direct index must allocate");
+) -> Result<Vec<CandidateEdge>, HnswError> {
+    let direct_index = CpuHnsw::with_capacity(hnsw_params, source.len().max(1))?;
     let mut expected_edges = Vec::new();
     for &index in indices {
-        let edges = direct_index
-            .insert_harvesting(index, source)
-            .expect("direct insert must succeed");
+        let edges = direct_index.insert_harvesting(index, source)?;
         expected_edges.extend(edges);
     }
-    expected_edges
+    Ok(expected_edges)
 }

--- a/chutoro-core/src/session/tests/common.rs
+++ b/chutoro-core/src/session/tests/common.rs
@@ -15,6 +15,10 @@ use crate::{
     DataSourceError, HnswError, HnswParams, MetricDescriptor,
 };
 
+/// An in-memory [`DataSource`] test double whose distance is the absolute
+/// difference between two values.
+///
+/// The source always reports the fixed name `"session-test"`.
 #[derive(Clone, Debug)]
 pub(super) struct SessionTestSource {
     values: Vec<f32>,
@@ -22,6 +26,7 @@ pub(super) struct SessionTestSource {
 }
 
 impl SessionTestSource {
+    /// Builds a source of `len` points valued `0.0, 1.0, ..., (len - 1) as f32`.
     pub(super) fn with_len(len: usize) -> Self {
         Self {
             values: (0..len).map(|value| value as f32).collect(),
@@ -56,13 +61,24 @@ impl DataSource for SessionTestSource {
     }
 }
 
+/// Returns a fresh [`ChutoroBuilder`] for tests to customize.
 #[fixture]
 pub(super) fn session_builder() -> ChutoroBuilder {
     ChutoroBuilder::new()
 }
 
+/// Pairs a constructed [`ClusteringSession`] with the `Arc` handle to its
+/// backing [`SessionTestSource`], so callers can inspect the source directly.
 pub(super) type SessionAndSource = (ClusteringSession<SessionTestSource>, Arc<SessionTestSource>);
 
+/// Builds a [`SessionTestSource`] of `source_len` points and constructs a
+/// session from it via `builder`.
+///
+/// # Errors
+///
+/// Propagates any [`ChutoroError`] returned by
+/// [`ChutoroBuilder::build_session`], for example an invalid builder
+/// configuration.
 pub(super) fn make_session(
     builder: ChutoroBuilder,
     source_len: usize,
@@ -72,6 +88,15 @@ pub(super) fn make_session(
     Ok((session, source))
 }
 
+/// Builds an independent batch HNSW oracle and harvests candidate edges for
+/// each of `indices`, in order, into a single accumulated `Vec`.
+///
+/// Used as ground truth against session-driven incremental insertion.
+///
+/// # Errors
+///
+/// Propagates any [`HnswError`] from [`CpuHnsw::with_capacity`] or from an
+/// `insert_harvesting` call, short-circuiting on the first failure.
 pub(super) fn harvest_expected_edges(
     hnsw_params: HnswParams,
     source: &SessionTestSource,

--- a/chutoro-core/src/session/tests/concurrency.rs
+++ b/chutoro-core/src/session/tests/concurrency.rs
@@ -17,7 +17,7 @@ use crate::ChutoroBuilder;
 fn concurrent_readers_observe_consistent_point_count(session_builder: ChutoroBuilder) {
     // Append two points on the writer thread, then share the session
     // read-only across multiple concurrent threads.
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
     session.append(&[0, 1]).expect("append must succeed");
     let shared = Arc::new(std::sync::RwLock::new(session));
 
@@ -45,7 +45,7 @@ fn concurrent_readers_observe_consistent_point_count(session_builder: ChutoroBui
 fn snapshot_version_is_immutable_under_concurrent_readers(session_builder: ChutoroBuilder) {
     // snapshot_version must read as 0 under all concurrent readers;
     // append does not publish a label snapshot.
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
     session.append(&[0, 1, 2]).expect("append must succeed");
     let shared = Arc::new(std::sync::RwLock::new(session));
 

--- a/chutoro-core/src/session/tests/core_distance.rs
+++ b/chutoro-core/src/session/tests/core_distance.rs
@@ -4,27 +4,31 @@
 //! appends mark core distances dirty, explicit recompute fills them, and full
 //! recompute mirrors the batch CPU path.
 
-use std::{collections::BTreeSet, num::NonZeroUsize, sync::Arc};
+use std::{collections::BTreeSet, sync::Arc};
 
 use proptest::prelude::*;
 use rstest::rstest;
 
 use super::common::{SessionTestSource, make_session, session_builder};
+use super::core_distance_support::{
+    assert_core_distances_eq, expected_batch_cores, monotonic_append_order, observed_cores,
+    unique_sorted,
+};
 use crate::{
-    ChutoroBuilder, CpuHnsw, DataSource, HnswParams, Neighbour,
-    session::core_distance::recompute_targets, test_utils::suite_proptest_config,
+    ChutoroBuilder, DataSource, HnswParams, Neighbour, session::core_distance::recompute_targets,
+    test_utils::suite_proptest_config,
 };
 
 #[rstest]
 fn core_distance_returns_none_before_append(session_builder: ChutoroBuilder) {
-    let (session, _) = make_session(session_builder, 4);
+    let (session, _) = make_session(session_builder, 4).expect("session must build");
 
     assert_eq!(session.core_distance(0), None);
 }
 
 #[rstest]
 fn core_distance_returns_none_after_append_before_recompute(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
 
     session.append(&[0, 1, 2, 3]).expect("append must succeed");
 
@@ -35,7 +39,7 @@ fn core_distance_returns_none_after_append_before_recompute(session_builder: Chu
 
 #[rstest]
 fn recompute_core_distances_clears_dirty_bits(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 4);
+    let (mut session, _) = make_session(session_builder, 4).expect("session must build");
 
     session.append(&[0, 1, 2, 3]).expect("append must succeed");
     session
@@ -53,14 +57,16 @@ fn recompute_core_distances_clears_dirty_bits(session_builder: ChutoroBuilder) {
 #[rstest]
 fn recompute_core_distances_matches_batch_per_point(session_builder: ChutoroBuilder) {
     let hnsw_params = HnswParams::default().with_rng_seed(7);
-    let (mut session, source) = make_session(session_builder.with_hnsw_params(hnsw_params), 4);
+    let (mut session, source) =
+        make_session(session_builder.with_hnsw_params(hnsw_params), 4).expect("session must build");
 
     session.append(&[0, 1, 2, 3]).expect("append must succeed");
     session
         .recompute_core_distances_full()
         .expect("full recompute must succeed");
 
-    let expected = expected_batch_cores(source.as_ref(), &session);
+    let expected =
+        expected_batch_cores(source.as_ref(), &session).expect("batch cores must compute");
     assert_core_distances_eq(&session, &expected);
 }
 
@@ -73,7 +79,8 @@ fn core_distance_matches_expected_batch_result_for_selection_and_fallback(
     #[case] use_full_recompute: bool,
     #[case] scenario: &str,
 ) {
-    let (mut session, source) = make_session(session_builder.with_min_cluster_size(3), point_count);
+    let (mut session, source) = make_session(session_builder.with_min_cluster_size(3), point_count)
+        .expect("session must build");
 
     let points: Vec<usize> = (0..point_count).collect();
     session.append(&points).expect("append must succeed");
@@ -88,7 +95,8 @@ fn core_distance_matches_expected_batch_result_for_selection_and_fallback(
             .expect("incremental recompute must succeed");
     }
 
-    let expected = expected_batch_cores(source.as_ref(), &session);
+    let expected =
+        expected_batch_cores(source.as_ref(), &session).expect("batch cores must compute");
     assert_eq!(
         session.core_distance(0),
         Some(expected[0]),
@@ -98,7 +106,8 @@ fn core_distance_matches_expected_batch_result_for_selection_and_fallback(
 
 #[rstest]
 fn core_distance_empty_neighbour_list_yields_zero(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder.with_min_cluster_size(3), 1);
+    let (mut session, _) =
+        make_session(session_builder.with_min_cluster_size(3), 1).expect("session must build");
 
     session.append(&[0]).expect("append must succeed");
     session
@@ -118,7 +127,8 @@ fn recompute_core_distances_recomputes_touched_existing_points(session_builder: 
             .with_min_cluster_size(1)
             .with_hnsw_params(hnsw_params),
         5,
-    );
+    )
+    .expect("session must build");
 
     session
         .append(&[0, 2, 4])
@@ -143,7 +153,7 @@ fn recompute_core_distances_recomputes_touched_existing_points(session_builder: 
 
 #[rstest]
 fn core_distance_out_of_range_returns_none(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 1);
+    let (mut session, _) = make_session(session_builder, 1).expect("session must build");
 
     session.append(&[0]).expect("append must succeed");
 
@@ -152,7 +162,7 @@ fn core_distance_out_of_range_returns_none(session_builder: ChutoroBuilder) {
 
 #[rstest]
 fn recompute_core_distances_full_recomputes_all_points(session_builder: ChutoroBuilder) {
-    let (mut session, source) = make_session(session_builder, 10);
+    let (mut session, source) = make_session(session_builder, 10).expect("session must build");
 
     session
         .append(&(0..8).collect::<Vec<_>>())
@@ -165,7 +175,8 @@ fn recompute_core_distances_full_recomputes_all_points(session_builder: ChutoroB
         .recompute_core_distances_full()
         .expect("full recompute must succeed");
 
-    let expected = expected_batch_cores(source.as_ref(), &session);
+    let expected =
+        expected_batch_cores(source.as_ref(), &session).expect("batch cores must compute");
     assert_core_distances_eq(&session, &expected);
 }
 
@@ -277,8 +288,11 @@ proptest! {
             .recompute_core_distances_full()
             .expect("full recompute must succeed");
 
-        let expected = expected_batch_cores(source.as_ref(), &session);
-        prop_assert_eq!(observed_cores(&session), expected);
+        let expected = expected_batch_cores(source.as_ref(), &session)
+            .expect("batch cores must compute");
+        let observed =
+            observed_cores(&session).expect("point must have a recomputed core distance");
+        prop_assert_eq!(observed, expected);
     }
 
     #[test]
@@ -298,96 +312,14 @@ proptest! {
         session
             .recompute_core_distances()
             .expect("incremental recompute must succeed");
-        let incremental = observed_cores(&session);
+        let incremental =
+            observed_cores(&session).expect("point must have a recomputed core distance");
 
         session
             .recompute_core_distances_full()
             .expect("full recompute must succeed");
 
-        prop_assert_eq!(incremental, observed_cores(&session));
+        let full = observed_cores(&session).expect("point must have a recomputed core distance");
+        prop_assert_eq!(incremental, full);
     }
-}
-
-/// Builds an independent batch HNSW index to act as the oracle for recompute parity.
-fn expected_batch_cores<D: DataSource + Send + Sync>(
-    source: &D,
-    session: &crate::ClusteringSession<D>,
-) -> Vec<f32> {
-    let items = session.point_count();
-    let params = session.config().hnsw_params().clone();
-    let index = CpuHnsw::build(source, params.clone()).expect("batch HNSW build must succeed");
-    let ef = expected_batch_ef(session.config().min_cluster_size(), &params, items);
-
-    (0..items)
-        .map(|point| {
-            let neighbours = index
-                .search(source, point, ef)
-                .expect("batch HNSW search must succeed");
-            let others = neighbours
-                .into_iter()
-                .filter(|neighbour| neighbour.id != point)
-                .collect::<Vec<_>>();
-            expected_core_from_sorted_others(&others, session.config().min_cluster_size())
-        })
-        .collect()
-}
-
-/// Selects the min-cluster neighbour, falling back to the last known neighbour or zero.
-fn expected_core_from_sorted_others(
-    neighbours: &[Neighbour],
-    min_cluster_size: NonZeroUsize,
-) -> f32 {
-    neighbours
-        .get(min_cluster_size.get() - 1)
-        .or_else(|| neighbours.last())
-        .map_or(0.0, |neighbour| neighbour.distance)
-}
-
-/// Mirrors batch EF: include the query slot, honour construction EF, and cap at item count.
-fn expected_batch_ef(
-    min_cluster_size: NonZeroUsize,
-    hnsw_params: &HnswParams,
-    items: usize,
-) -> NonZeroUsize {
-    let desired = min_cluster_size
-        .get()
-        .saturating_add(1)
-        .max(hnsw_params.ef_construction())
-        .min(items);
-    NonZeroUsize::new(desired).unwrap_or(min_cluster_size)
-}
-
-/// Extracts every recomputed core distance from the session.
-fn observed_cores<D: DataSource + Send + Sync>(session: &crate::ClusteringSession<D>) -> Vec<f32> {
-    (0..session.point_count())
-        .map(|point| {
-            session
-                .core_distance(point)
-                .expect("point must have a recomputed core distance")
-        })
-        .collect()
-}
-
-/// Validates observed core distances against the batch oracle.
-fn assert_core_distances_eq<D: DataSource + Send + Sync>(
-    session: &crate::ClusteringSession<D>,
-    expected: &[f32],
-) {
-    assert_eq!(observed_cores(session), expected);
-}
-
-/// Sorts and deduplicates point indices for stable comparisons.
-fn unique_sorted(mut values: Vec<usize>) -> Vec<usize> {
-    values.sort_unstable();
-    values.dedup();
-    values
-}
-
-/// Front-loads enough unique points so every prefixed point is saturated before tail appends.
-fn monotonic_append_order(min_cluster_size: usize, tail: Vec<usize>) -> Vec<usize> {
-    let prefix = 0..=min_cluster_size;
-    let mut seen = prefix.clone().collect::<BTreeSet<_>>();
-    prefix
-        .chain(tail.into_iter().filter(|index| seen.insert(*index)))
-        .collect()
 }

--- a/chutoro-core/src/session/tests/core_distance_errors.rs
+++ b/chutoro-core/src/session/tests/core_distance_errors.rs
@@ -1,6 +1,7 @@
 //! Error and invariant tests for session core-distance recomputation.
 
 use std::{
+    error::Error,
     num::NonZeroUsize,
     sync::{
         Arc,
@@ -20,7 +21,7 @@ use crate::{
 #[rstest]
 #[should_panic(expected = "assertion `left == right` failed")]
 fn core_distance_asserts_storage_alignment(session_builder: ChutoroBuilder) {
-    let (mut session, _) = make_session(session_builder, 1);
+    let (mut session, _) = make_session(session_builder, 1).expect("session must build");
 
     session.append(&[0]).expect("append must succeed");
     session.dirty_core_distances.clear();
@@ -36,7 +37,7 @@ fn recompute_core_distances_propagates_errors(
     #[case] failure_description: &str,
 ) {
     let source = Arc::new(FailableSource::new(mode));
-    let mut session = build_failable_session(Arc::clone(&source));
+    let mut session = build_failable_session(Arc::clone(&source)).expect("session must build");
 
     session.append(&[0, 1, 2]).expect("append must succeed");
     source.fail();
@@ -64,7 +65,7 @@ fn recompute_core_distances_keeps_new_points_dirty_when_existing_search_fails() 
         left: 0,
         right: 2,
     }));
-    let mut session = build_failable_session(Arc::clone(&source));
+    let mut session = build_failable_session(Arc::clone(&source)).expect("session must build");
 
     session.append(&[0, 2]).expect("first append must succeed");
     session
@@ -95,19 +96,18 @@ fn recompute_core_distances_keeps_new_points_dirty_when_existing_search_fails() 
     assert!(session.core_distance(1).is_some());
 }
 
-fn build_failable_session(source: Arc<FailableSource>) -> crate::ClusteringSession<FailableSource> {
-    let cache_entries = NonZeroUsize::new(1).expect("cache size must be non-zero");
-    let hnsw_params = HnswParams::new(2, 4)
-        .expect("HNSW params must be valid")
-        .with_distance_cache_config(
-            DistanceCacheConfig::new(cache_entries).with_ttl(Some(Duration::ZERO)),
-        );
+fn build_failable_session(
+    source: Arc<FailableSource>,
+) -> Result<crate::ClusteringSession<FailableSource>, Box<dyn Error>> {
+    let cache_entries = NonZeroUsize::new(1).ok_or("cache size must be non-zero")?;
+    let hnsw_params = HnswParams::new(2, 4)?.with_distance_cache_config(
+        DistanceCacheConfig::new(cache_entries).with_ttl(Some(Duration::ZERO)),
+    );
 
-    ChutoroBuilder::new()
+    Ok(ChutoroBuilder::new()
         .with_min_cluster_size(1)
         .with_hnsw_params(hnsw_params)
-        .build_session(source)
-        .expect("session must build")
+        .build_session(source)?)
 }
 
 #[derive(Debug)]

--- a/chutoro-core/src/session/tests/core_distance_support.rs
+++ b/chutoro-core/src/session/tests/core_distance_support.rs
@@ -1,0 +1,93 @@
+//! Batch-oracle helpers for the core-distance session tests.
+//!
+//! These helpers build the independent batch HNSW oracle, extract observed
+//! core distances, and shape append orders so `core_distance.rs` stays
+//! focused on the behaviours under test.
+
+use std::{collections::BTreeSet, num::NonZeroUsize};
+
+use crate::{ClusteringSession, CpuHnsw, DataSource, HnswError, HnswParams, Neighbour};
+
+/// Builds an independent batch HNSW index to act as the oracle for recompute parity.
+pub(super) fn expected_batch_cores<D: DataSource + Send + Sync>(
+    source: &D,
+    session: &ClusteringSession<D>,
+) -> Result<Vec<f32>, HnswError> {
+    let items = session.point_count();
+    let params = session.config().hnsw_params().clone();
+    let index = CpuHnsw::build(source, params.clone())?;
+    let ef = expected_batch_ef(session.config().min_cluster_size(), &params, items);
+
+    (0..items)
+        .map(|point| {
+            let neighbours = index.search(source, point, ef)?;
+            let others = neighbours
+                .into_iter()
+                .filter(|neighbour| neighbour.id != point)
+                .collect::<Vec<_>>();
+            Ok(expected_core_from_sorted_others(
+                &others,
+                session.config().min_cluster_size(),
+            ))
+        })
+        .collect()
+}
+
+/// Selects the min-cluster neighbour, falling back to the last known neighbour or zero.
+fn expected_core_from_sorted_others(
+    neighbours: &[Neighbour],
+    min_cluster_size: NonZeroUsize,
+) -> f32 {
+    neighbours
+        .get(min_cluster_size.get() - 1)
+        .or_else(|| neighbours.last())
+        .map_or(0.0, |neighbour| neighbour.distance)
+}
+
+/// Mirrors batch EF: include the query slot, honour construction EF, and cap at item count.
+fn expected_batch_ef(
+    min_cluster_size: NonZeroUsize,
+    hnsw_params: &HnswParams,
+    items: usize,
+) -> NonZeroUsize {
+    let desired = min_cluster_size
+        .get()
+        .saturating_add(1)
+        .max(hnsw_params.ef_construction())
+        .min(items);
+    NonZeroUsize::new(desired).unwrap_or(min_cluster_size)
+}
+
+/// Extracts every recomputed core distance from the session, or `None` when
+/// any point still lacks one.
+pub(super) fn observed_cores<D: DataSource + Send + Sync>(
+    session: &ClusteringSession<D>,
+) -> Option<Vec<f32>> {
+    (0..session.point_count())
+        .map(|point| session.core_distance(point))
+        .collect()
+}
+
+/// Validates observed core distances against the batch oracle.
+pub(super) fn assert_core_distances_eq<D: DataSource + Send + Sync>(
+    session: &ClusteringSession<D>,
+    expected: &[f32],
+) {
+    assert_eq!(observed_cores(session).as_deref(), Some(expected));
+}
+
+/// Sorts and deduplicates point indices for stable comparisons.
+pub(super) fn unique_sorted(mut values: Vec<usize>) -> Vec<usize> {
+    values.sort_unstable();
+    values.dedup();
+    values
+}
+
+/// Front-loads enough unique points so every prefixed point is saturated before tail appends.
+pub(super) fn monotonic_append_order(min_cluster_size: usize, tail: Vec<usize>) -> Vec<usize> {
+    let prefix = 0..=min_cluster_size;
+    let mut seen = prefix.clone().collect::<BTreeSet<_>>();
+    prefix
+        .chain(tail.into_iter().filter(|index| seen.insert(*index)))
+        .collect()
+}

--- a/chutoro-core/src/session/tests/metrics.rs
+++ b/chutoro-core/src/session/tests/metrics.rs
@@ -23,7 +23,7 @@ fn append_records_deterministic_latency_via_clock_seam(session_builder: ChutoroB
     let snapshotter = recorder.snapshotter();
     metrics::with_local_recorder(&recorder, || {
         // Build a session with a fixed clock that reports exactly 5 ms per point.
-        let (session, _) = make_session(session_builder, 4);
+        let (session, _) = make_session(session_builder, 4).expect("session must build");
         let clock = Arc::new(crate::session::clock::FixedMonotonicClock::with_elapsed(
             Duration::from_millis(5),
         ));

--- a/chutoro-providers/dense/src/simd/tests/parity/mod.rs
+++ b/chutoro-providers/dense/src/simd/tests/parity/mod.rs
@@ -62,14 +62,16 @@ pub(super) fn proptest_config(default_cases: u32) -> ProptestConfig {
 /// Backends come from [`dispatch::enabled_backends`], then
 /// [`kernels::pairwise_entry`] resolves each compiled-and-runtime-available
 /// backend to its pairwise entry point before the pairs are collected. Missing
-/// entry points are programming errors and panic instead of being skipped.
-fn pairwise_entries() -> Vec<(dispatch::EuclideanBackend, PairwiseEntry)> {
+/// entry points are programming errors, reported as `Err` so the calling test
+/// fails instead of skipping the backend.
+fn pairwise_entries() -> Result<Vec<(dispatch::EuclideanBackend, PairwiseEntry)>, String> {
     dispatch::enabled_backends()
         .into_iter()
         .map(|backend| {
-            let entry = kernels::pairwise_entry(backend)
-                .expect("enabled backend must have a pairwise kernel entrypoint");
-            (backend, entry)
+            let entry = kernels::pairwise_entry(backend).ok_or_else(|| {
+                format!("enabled backend {backend:?} must have a pairwise kernel entrypoint")
+            })?;
+            Ok((backend, entry))
         })
         .collect()
 }
@@ -79,15 +81,17 @@ fn pairwise_entries() -> Vec<(dispatch::EuclideanBackend, PairwiseEntry)> {
 /// Backends come from [`dispatch::enabled_backends`], then
 /// [`kernels::query_points_entry`] resolves each
 /// compiled-and-runtime-available backend to its query-to-points entry point
-/// before the pairs are collected. Missing entry points are programming errors
-/// and panic instead of being skipped.
-fn query_points_entries() -> Vec<(dispatch::EuclideanBackend, QueryPointsEntry)> {
+/// before the pairs are collected. Missing entry points are programming
+/// errors, reported as `Err` so the calling test fails instead of skipping
+/// the backend.
+fn query_points_entries() -> Result<Vec<(dispatch::EuclideanBackend, QueryPointsEntry)>, String> {
     dispatch::enabled_backends()
         .into_iter()
         .map(|backend| {
-            let entry = kernels::query_points_entry(backend)
-                .expect("enabled backend must have a query-points kernel entrypoint");
-            (backend, entry)
+            let entry = kernels::query_points_entry(backend).ok_or_else(|| {
+                format!("enabled backend {backend:?} must have a query-points kernel entrypoint")
+            })?;
+            Ok((backend, entry))
         })
         .collect()
 }

--- a/chutoro-providers/dense/src/simd/tests/parity/non_finite.rs
+++ b/chutoro-providers/dense/src/simd/tests/parity/non_finite.rs
@@ -27,7 +27,7 @@ proptest! {
     ) {
         let semantics = DistanceSemantics::default_euclidean();
         let expected = semantics.oracle_pairwise(&left, &right);
-        let entries = super::pairwise_entries();
+        let entries = super::pairwise_entries().expect("parity backends must enumerate");
 
         prop_assert!(expected.is_nan(), "scalar oracle must canonicalize to NaN");
         prop_assert!(!entries.is_empty(), "at least scalar backend must be available");
@@ -52,7 +52,7 @@ proptest! {
             .expect("query row must exist because fixture.query_index() is always within bounds");
         let points = DensePointView::from_row_indices(matrix, &fixture.point_indices())
             .expect("point rows must exist because fixture point indices are generated in bounds");
-        let entries = super::query_points_entries();
+        let entries = super::query_points_entries().expect("parity backends must enumerate");
         let mut expected = vec![0.0_f32; points.point_count()];
 
         semantics.oracle_query_points(query.as_slice(), &points, &mut expected);

--- a/chutoro-providers/dense/src/simd/tests/parity/pairwise.rs
+++ b/chutoro-providers/dense/src/simd/tests/parity/pairwise.rs
@@ -23,7 +23,7 @@ proptest! {
     fn pairwise_backends_match_scalar_oracle((left, right) in strategies::finite_vector_pair()) {
         let semantics = DistanceSemantics::default_euclidean();
         let expected = semantics.oracle_pairwise(&left, &right);
-        let entries = super::pairwise_entries();
+        let entries = super::pairwise_entries().expect("parity backends must enumerate");
 
         prop_assert!(!entries.is_empty(), "at least scalar backend must be available");
         for (_backend, entry) in entries {

--- a/chutoro-providers/dense/src/simd/tests/parity/query_points.rs
+++ b/chutoro-providers/dense/src/simd/tests/parity/query_points.rs
@@ -30,7 +30,7 @@ proptest! {
             .expect("query row must exist because fixture.query_index() is always within bounds");
         let points = DensePointView::from_row_indices(matrix, &fixture.point_indices())
             .expect("point rows must exist because fixture point indices are generated in bounds");
-        let entries = super::query_points_entries();
+        let entries = super::query_points_entries().expect("parity backends must enumerate");
         let mut expected = vec![0.0_f32; points.point_count()];
 
         semantics.oracle_query_points(query.as_slice(), &points, &mut expected);

--- a/chutoro-providers/dense/src/tests/ingest.rs
+++ b/chutoro-providers/dense/src/tests/ingest.rs
@@ -13,8 +13,8 @@ use std::sync::Arc;
 
 #[rstest]
 fn matrix_provider_from_parquet() {
-    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
-    let bytes = write_parquet(array);
+    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).expect("fixture array must build");
+    let bytes = write_parquet(array).expect("parquet fixture must serialize");
     let provider = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "features")
         .expect("parquet load");
     assert_eq!(provider.len(), 2);
@@ -26,10 +26,11 @@ fn matrix_provider_from_parquet() {
 fn matrix_provider_from_parquet_multiple_batches() {
     let first_rows = vec![vec![1.0, 2.0, 3.0], vec![7.0, 8.0, 9.0]];
     let second_rows = vec![vec![4.0, 5.0, 6.0]];
-    let first = build_list_array(&first_rows, 3, false);
-    let second = build_list_array(&second_rows, 3, false);
-    let field = feature_field(3, false, false);
-    let bytes = write_parquet_two_batches(first, second, field);
+    let first = build_list_array(&first_rows, 3, false).expect("fixture array must build");
+    let second = build_list_array(&second_rows, 3, false).expect("fixture array must build");
+    let field = feature_field(3, false, false).expect("feature field must build");
+    let bytes =
+        write_parquet_two_batches(first, second, field).expect("parquet fixture must serialize");
     let provider = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "features")
         .expect("parquet load across batches");
     assert_eq!(provider.len(), 3);
@@ -42,8 +43,8 @@ fn matrix_provider_from_parquet_multiple_batches() {
 
 #[rstest]
 fn matrix_provider_parquet_missing_column() {
-    let array = build_array(&[[1.0, 2.0, 3.0]]);
-    let bytes = write_parquet(array);
+    let array = build_array(&[[1.0, 2.0, 3.0]]).expect("fixture array must build");
+    let bytes = write_parquet(array).expect("parquet fixture must serialize");
     let err = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "unknown")
         .expect_err("missing column");
     assert!(matches!(
@@ -82,8 +83,8 @@ fn matrix_provider_parquet_wrong_type() {
 fn matrix_provider_parquet_inconsistent_dimension() {
     let batch_one = {
         let rows = vec![vec![1.0, 2.0, 3.0]];
-        let array = build_list_array(&rows, 3, false);
-        let field = feature_field(3, false, false);
+        let array = build_list_array(&rows, 3, false).expect("fixture array must build");
+        let field = feature_field(3, false, false).expect("feature field must build");
         RecordBatch::try_new(
             Arc::new(Schema::new(vec![field])),
             vec![Arc::new(array) as _],
@@ -92,8 +93,8 @@ fn matrix_provider_parquet_inconsistent_dimension() {
     };
     let batch_two = {
         let rows = vec![vec![4.0, 5.0]];
-        let array = build_list_array(&rows, 2, false);
-        let field = feature_field(2, false, false);
+        let array = build_list_array(&rows, 2, false).expect("fixture array must build");
+        let field = feature_field(2, false, false).expect("feature field must build");
         RecordBatch::try_new(
             Arc::new(Schema::new(vec![field])),
             vec![Arc::new(array) as _],
@@ -119,9 +120,9 @@ fn matrix_provider_parquet_nullable_schema(
     #[case] child_nullable: bool,
 ) {
     let rows = vec![vec![1.0, 2.0, 3.0]];
-    let array = build_list_array(&rows, 3, child_nullable);
-    let field = feature_field(3, child_nullable, list_nullable);
-    let bytes = write_parquet_with_field(field, array);
+    let array = build_list_array(&rows, 3, child_nullable).expect("fixture array must build");
+    let field = feature_field(3, child_nullable, list_nullable).expect("feature field must build");
+    let bytes = write_parquet_with_field(field, array).expect("parquet fixture must serialize");
     let err = DenseMatrixProvider::try_from_parquet_reader("demo", bytes, "features")
         .expect_err("nullable schema must be rejected");
     assert!(matches!(
@@ -148,7 +149,7 @@ fn validate_field_rejects_negative_dimension() {
 #[test]
 fn copy_list_values_rejects_null_row() {
     let rows = vec![None, Some(vec![1.0, 2.0, 3.0])];
-    let array = build_list_array_with_row_nulls(&rows, 3);
+    let array = build_list_array_with_row_nulls(&rows, 3).expect("fixture array must build");
     let mut values = Vec::new();
     let err = copy_list_values(&array, 3, 0, &mut values).expect_err("null row must be rejected");
     assert!(matches!(
@@ -163,7 +164,7 @@ fn copy_list_values_rejects_null_value() {
         vec![Some(1.0), Some(2.0), Some(3.0)],
         vec![Some(4.0), None, Some(6.0)],
     ];
-    let array = build_list_array_with_value_nulls(&rows, 3);
+    let array = build_list_array_with_value_nulls(&rows, 3).expect("fixture array must build");
     let mut values = Vec::new();
     let err = copy_list_values(&array, 3, 0, &mut values).expect_err("null value must be rejected");
     assert!(matches!(
@@ -178,7 +179,7 @@ fn copy_list_values_rejects_null_value() {
 #[test]
 fn copy_list_values_rejects_incorrect_length() {
     let rows = vec![vec![1.0, 2.0]];
-    let array = build_list_array(&rows, 2, false);
+    let array = build_list_array(&rows, 2, false).expect("fixture array must build");
     let mut values = Vec::new();
     let err = copy_list_values(&array, 3, 0, &mut values)
         .expect_err("incorrect lengths must be rejected");

--- a/chutoro-providers/dense/src/tests/provider.rs
+++ b/chutoro-providers/dense/src/tests/provider.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 
 #[rstest]
 fn matrix_provider_from_fixed_size_list() {
-    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).expect("fixture array must build");
     let provider =
         DenseMatrixProvider::try_from_fixed_size_list("demo", &array).expect("valid matrix");
     assert_eq!(provider.len(), 2);
@@ -27,7 +27,7 @@ fn matrix_provider_from_fixed_size_list() {
 
 #[rstest]
 fn matrix_provider_distance_batch() {
-    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).expect("fixture array must build");
     let provider =
         DenseMatrixProvider::try_from_fixed_size_list("demo", &array).expect("valid matrix");
     let pairs = vec![(0, 1), (1, 0)];
@@ -189,7 +189,7 @@ fn matrix_provider_distance_batch_preserves_output_on_error() {
 
 #[rstest]
 fn matrix_provider_distance_out_of_bounds() {
-    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).expect("fixture array must build");
     let provider =
         DenseMatrixProvider::try_from_fixed_size_list("demo", &array).expect("valid matrix");
     let err = provider
@@ -203,7 +203,7 @@ fn matrix_provider_distance_out_of_bounds() {
 
 #[rstest]
 fn matrix_provider_distance_batch_length_mismatch() {
-    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+    let array = build_array(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).expect("fixture array must build");
     let provider =
         DenseMatrixProvider::try_from_fixed_size_list("demo", &array).expect("valid matrix");
     let pairs = vec![(0, 1)];
@@ -222,7 +222,7 @@ fn matrix_provider_distance_batch_length_mismatch() {
 
 #[rstest]
 fn matrix_provider_distance_batch_empty() {
-    let array = build_array(&[[1.0, 2.0, 3.0]]);
+    let array = build_array(&[[1.0, 2.0, 3.0]]).expect("fixture array must build");
     let provider =
         DenseMatrixProvider::try_from_fixed_size_list("demo", &array).expect("valid matrix");
     let pairs: Vec<(usize, usize)> = Vec::new();
@@ -263,7 +263,7 @@ fn scalar_distance(left: &[f32], right: &[f32]) -> f32 {
 #[rstest]
 fn matrix_provider_rejects_null_rows() {
     let rows = vec![Some(vec![1.0, 2.0]), None];
-    let array = build_list_array_with_row_nulls(&rows, 2);
+    let array = build_list_array_with_row_nulls(&rows, 2).expect("fixture array must build");
     let err = DenseMatrixProvider::try_from_fixed_size_list("demo", &array)
         .expect_err("null rows must be rejected");
     assert!(matches!(err, DenseMatrixProviderError::NullRow { row: 1 }));
@@ -272,7 +272,7 @@ fn matrix_provider_rejects_null_rows() {
 #[rstest]
 fn matrix_provider_rejects_null_values() {
     let rows = vec![vec![Some(1.0), Some(2.0)], vec![Some(3.0), None]];
-    let array = build_list_array_with_value_nulls(&rows, 2);
+    let array = build_list_array_with_value_nulls(&rows, 2).expect("fixture array must build");
     let err = DenseMatrixProvider::try_from_fixed_size_list("demo", &array)
         .expect_err("null values must be rejected");
     assert!(matches!(

--- a/chutoro-providers/dense/src/tests/support.rs
+++ b/chutoro-providers/dense/src/tests/support.rs
@@ -1,7 +1,7 @@
 //! Test support utilities for constructing Arrow arrays, Parquet data, and DenseMatrixProvider
 //! instances from RecordBatches. Provides helpers for building FixedSizeListArray fixtures with
 //! various null-handling patterns (row nulls, value nulls) and for serializing arrays to Parquet
-//! format for ingest testing.
+//! format for ingest testing. Helpers are fallible so tests decide how failures are reported.
 
 use super::{DenseMatrixProvider, DenseMatrixProviderError};
 use crate::ingest::{append_fixed_size_list_values, validate_fixed_size_list_field};
@@ -10,9 +10,9 @@ use arrow_array::{Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch
 use arrow_schema::{DataType, Field, Schema};
 use bytes::Bytes;
 use parquet::arrow::arrow_writer::ArrowWriter;
-use std::{convert::TryFrom, iter, sync::Arc};
+use std::{convert::TryFrom, error::Error, iter, sync::Arc};
 
-pub(crate) fn build_array(rows: &[[f32; 3]]) -> FixedSizeListArray {
+pub(crate) fn build_array(rows: &[[f32; 3]]) -> Result<FixedSizeListArray, Box<dyn Error>> {
     let rows = rows.iter().map(|row| row.to_vec()).collect::<Vec<_>>();
     build_list_array(&rows, 3, false)
 }
@@ -21,7 +21,7 @@ pub(crate) fn build_list_array(
     rows: &[Vec<f32>],
     dimension: usize,
     child_nullable: bool,
-) -> FixedSizeListArray {
+) -> Result<FixedSizeListArray, Box<dyn Error>> {
     assert!(rows.iter().all(|row| row.len() == dimension));
     let values = Float32Array::from_iter_values(rows.iter().flatten().copied());
     fixed_size_list_from_values(values, dimension, child_nullable)
@@ -30,7 +30,7 @@ pub(crate) fn build_list_array(
 pub(crate) fn build_list_array_with_row_nulls(
     rows: &[Option<Vec<f32>>],
     dimension: usize,
-) -> FixedSizeListArray {
+) -> Result<FixedSizeListArray, Box<dyn Error>> {
     assert!(
         rows.iter()
             .all(|row| { row.as_ref().is_none_or(|values| values.len() == dimension) })
@@ -50,32 +50,36 @@ pub(crate) fn build_list_array_with_row_nulls(
         }
     }
     let values = Float32Array::from(flat);
-    FixedSizeListArray::new(
+    Ok(FixedSizeListArray::new(
         Arc::new(Field::new("item", DataType::Float32, false)),
-        i32::try_from(dimension).expect("dimension fits in i32"),
+        i32::try_from(dimension)?,
         Arc::new(values) as ArrayRef,
         Some(validity.finish().into()),
-    )
+    ))
 }
 
 pub(crate) fn build_list_array_with_value_nulls(
     rows: &[Vec<Option<f32>>],
     dimension: usize,
-) -> FixedSizeListArray {
+) -> Result<FixedSizeListArray, Box<dyn Error>> {
     assert!(rows.iter().all(|row| row.len() == dimension));
     let values = Float32Array::from_iter(rows.iter().flatten().copied());
     fixed_size_list_from_values(values, dimension, true)
 }
 
-pub(crate) fn feature_field(dimension: usize, child_nullable: bool, list_nullable: bool) -> Field {
-    Field::new(
+pub(crate) fn feature_field(
+    dimension: usize,
+    child_nullable: bool,
+    list_nullable: bool,
+) -> Result<Field, Box<dyn Error>> {
+    Ok(Field::new(
         "features",
         DataType::FixedSizeList(
             Arc::new(Field::new("item", DataType::Float32, child_nullable)),
-            i32::try_from(dimension).expect("dimension fits in i32"),
+            i32::try_from(dimension)?,
         ),
         list_nullable,
-    )
+    ))
 }
 
 pub(crate) fn try_from_record_batches(
@@ -125,53 +129,53 @@ pub(crate) fn try_from_record_batches(
     ))
 }
 
-pub(crate) fn write_parquet(array: FixedSizeListArray) -> Bytes {
-    let field = feature_field(3, false, false);
+pub(crate) fn write_parquet(array: FixedSizeListArray) -> Result<Bytes, Box<dyn Error>> {
+    let field = feature_field(3, false, false)?;
     write_parquet_with_field(field, array)
 }
 
-pub(crate) fn write_parquet_with_field(field: Field, array: FixedSizeListArray) -> Bytes {
+pub(crate) fn write_parquet_with_field(
+    field: Field,
+    array: FixedSizeListArray,
+) -> Result<Bytes, Box<dyn Error>> {
     let schema = Arc::new(Schema::new(vec![field.clone()]));
-    let batch =
-        RecordBatch::try_new(schema.clone(), vec![Arc::new(array) as ArrayRef]).expect("batch");
+    let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array) as ArrayRef])?;
     let mut buffer = Vec::new();
     {
-        let mut writer = ArrowWriter::try_new(&mut buffer, schema, None).expect("writer");
-        writer.write(&batch).expect("write");
-        writer.close().expect("close");
+        let mut writer = ArrowWriter::try_new(&mut buffer, schema, None)?;
+        writer.write(&batch)?;
+        writer.close()?;
     }
-    Bytes::from(buffer)
+    Ok(Bytes::from(buffer))
 }
 
 pub(crate) fn write_parquet_two_batches(
     first: FixedSizeListArray,
     second: FixedSizeListArray,
     field: Field,
-) -> Bytes {
+) -> Result<Bytes, Box<dyn Error>> {
     let schema = Arc::new(Schema::new(vec![field]));
-    let batch_one =
-        RecordBatch::try_new(schema.clone(), vec![Arc::new(first) as ArrayRef]).expect("batch one");
-    let batch_two = RecordBatch::try_new(schema.clone(), vec![Arc::new(second) as ArrayRef])
-        .expect("batch two");
+    let batch_one = RecordBatch::try_new(schema.clone(), vec![Arc::new(first) as ArrayRef])?;
+    let batch_two = RecordBatch::try_new(schema.clone(), vec![Arc::new(second) as ArrayRef])?;
     let mut buffer = Vec::new();
     {
-        let mut writer = ArrowWriter::try_new(&mut buffer, schema, None).expect("writer");
-        writer.write(&batch_one).expect("write batch one");
-        writer.write(&batch_two).expect("write batch two");
-        writer.close().expect("close");
+        let mut writer = ArrowWriter::try_new(&mut buffer, schema, None)?;
+        writer.write(&batch_one)?;
+        writer.write(&batch_two)?;
+        writer.close()?;
     }
-    Bytes::from(buffer)
+    Ok(Bytes::from(buffer))
 }
 
 fn fixed_size_list_from_values(
     values: Float32Array,
     dimension: usize,
     child_nullable: bool,
-) -> FixedSizeListArray {
-    FixedSizeListArray::new(
+) -> Result<FixedSizeListArray, Box<dyn Error>> {
+    Ok(FixedSizeListArray::new(
         Arc::new(Field::new("item", DataType::Float32, child_nullable)),
-        i32::try_from(dimension).expect("dimension fits in i32"),
+        i32::try_from(dimension)?,
         Arc::new(values) as ArrayRef,
         None,
-    )
+    ))
 }

--- a/chutoro-providers/dense/src/tests/support.rs
+++ b/chutoro-providers/dense/src/tests/support.rs
@@ -7,39 +7,107 @@ use super::{DenseMatrixProvider, DenseMatrixProviderError};
 use crate::ingest::{append_fixed_size_list_values, validate_fixed_size_list_field};
 use arrow_array::builder::BooleanBufferBuilder;
 use arrow_array::{Array, ArrayRef, FixedSizeListArray, Float32Array, RecordBatch};
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::{ArrowError, DataType, Field, Schema};
 use bytes::Bytes;
 use parquet::arrow::arrow_writer::ArrowWriter;
-use std::{convert::TryFrom, error::Error, iter, sync::Arc};
+use parquet::errors::ParquetError;
+use std::{convert::TryFrom, iter, num::TryFromIntError, sync::Arc};
 
-pub(crate) fn build_array(rows: &[[f32; 3]]) -> Result<FixedSizeListArray, Box<dyn Error>> {
+/// Failure modes of the Arrow and Parquet fixture builders.
+///
+/// Naming each source keeps the helpers self-documenting: a malformed fixture
+/// (`RowLength`, `Dimension`) is distinguishable from an Arrow or Parquet
+/// failure raised while assembling the fixture.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FixtureError {
+    /// A fixture row did not contain exactly `expected` values.
+    #[error("row {row} has {actual} values but the fixture dimension is {expected}")]
+    RowLength {
+        /// Zero-based index of the offending row.
+        row: usize,
+        /// Fixture dimension every row must match.
+        expected: usize,
+        /// Number of values the row actually contained.
+        actual: usize,
+    },
+    /// The dimension did not fit Arrow's `i32` fixed-size-list width.
+    #[error("fixture dimension does not fit an i32 list width")]
+    Dimension(#[from] TryFromIntError),
+    /// Arrow rejected the record batch or schema.
+    #[error(transparent)]
+    Arrow(#[from] ArrowError),
+    /// Parquet serialization failed.
+    #[error(transparent)]
+    Parquet(#[from] ParquetError),
+}
+
+/// Checks that a fixture row holds exactly `dimension` values.
+///
+/// # Errors
+/// Returns [`FixtureError::RowLength`] when `actual` differs from `dimension`.
+fn ensure_row_len(row: usize, actual: usize, dimension: usize) -> Result<(), FixtureError> {
+    if actual == dimension {
+        return Ok(());
+    }
+    Err(FixtureError::RowLength {
+        row,
+        expected: dimension,
+        actual,
+    })
+}
+
+/// Builds a non-nullable three-dimensional fixed-size list array.
+///
+/// Convenience wrapper over [`build_list_array`] for the common three-feature
+/// fixture shape; every row supplies exactly three values by construction.
+///
+/// # Errors
+/// Propagates any [`FixtureError`] raised by [`build_list_array`].
+pub(crate) fn build_array(rows: &[[f32; 3]]) -> Result<FixedSizeListArray, FixtureError> {
     let rows = rows.iter().map(|row| row.to_vec()).collect::<Vec<_>>();
     build_list_array(&rows, 3, false)
 }
 
+/// Builds a fixed-size list array from dense rows with no nulls.
+///
+/// Every row must contain exactly `dimension` values. `child_nullable` sets the
+/// nullability flag on the list's item field, letting tests exercise schema
+/// validation independently of the actual null buffer.
+///
+/// # Errors
+/// Returns [`FixtureError::RowLength`] if any row length differs from
+/// `dimension`, or [`FixtureError::Dimension`] if `dimension` exceeds `i32`.
 pub(crate) fn build_list_array(
     rows: &[Vec<f32>],
     dimension: usize,
     child_nullable: bool,
-) -> Result<FixedSizeListArray, Box<dyn Error>> {
-    assert!(rows.iter().all(|row| row.len() == dimension));
+) -> Result<FixedSizeListArray, FixtureError> {
+    for (index, row) in rows.iter().enumerate() {
+        ensure_row_len(index, row.len(), dimension)?;
+    }
     let values = Float32Array::from_iter_values(rows.iter().flatten().copied());
     fixed_size_list_from_values(values, dimension, child_nullable)
 }
 
+/// Builds a fixed-size list array where whole rows may be null.
+///
+/// `None` rows are recorded in the validity buffer and back-filled with zeroed
+/// values so the child array keeps its fixed stride; `Some` rows must contain
+/// exactly `dimension` values.
+///
+/// # Errors
+/// Returns [`FixtureError::RowLength`] if a present row's length differs from
+/// `dimension`, or [`FixtureError::Dimension`] if `dimension` exceeds `i32`.
 pub(crate) fn build_list_array_with_row_nulls(
     rows: &[Option<Vec<f32>>],
     dimension: usize,
-) -> Result<FixedSizeListArray, Box<dyn Error>> {
-    assert!(
-        rows.iter()
-            .all(|row| { row.as_ref().is_none_or(|values| values.len() == dimension) })
-    );
+) -> Result<FixedSizeListArray, FixtureError> {
     let mut flat = Vec::with_capacity(rows.len() * dimension);
     let mut validity = BooleanBufferBuilder::new(rows.len());
-    for row in rows {
+    for (index, row) in rows.iter().enumerate() {
         match row {
             Some(values) => {
+                ensure_row_len(index, values.len(), dimension)?;
                 validity.append(true);
                 flat.extend_from_slice(values);
             }
@@ -58,20 +126,38 @@ pub(crate) fn build_list_array_with_row_nulls(
     ))
 }
 
+/// Builds a fixed-size list array where individual values may be null.
+///
+/// Every row must contain exactly `dimension` entries, each of which may be
+/// `None`; the resulting list marks its item field nullable.
+///
+/// # Errors
+/// Returns [`FixtureError::RowLength`] if any row length differs from
+/// `dimension`, or [`FixtureError::Dimension`] if `dimension` exceeds `i32`.
 pub(crate) fn build_list_array_with_value_nulls(
     rows: &[Vec<Option<f32>>],
     dimension: usize,
-) -> Result<FixedSizeListArray, Box<dyn Error>> {
-    assert!(rows.iter().all(|row| row.len() == dimension));
+) -> Result<FixedSizeListArray, FixtureError> {
+    for (index, row) in rows.iter().enumerate() {
+        ensure_row_len(index, row.len(), dimension)?;
+    }
     let values = Float32Array::from_iter(rows.iter().flatten().copied());
     fixed_size_list_from_values(values, dimension, true)
 }
 
+/// Builds the `features` schema field describing a fixed-size list column.
+///
+/// `child_nullable` and `list_nullable` control the item and list nullability
+/// flags independently so tests can construct schemas that a provider should
+/// accept or reject.
+///
+/// # Errors
+/// Returns [`FixtureError::Dimension`] if `dimension` exceeds `i32`.
 pub(crate) fn feature_field(
     dimension: usize,
     child_nullable: bool,
     list_nullable: bool,
-) -> Result<Field, Box<dyn Error>> {
+) -> Result<Field, FixtureError> {
     Ok(Field::new(
         "features",
         DataType::FixedSizeList(
@@ -129,16 +215,31 @@ pub(crate) fn try_from_record_batches(
     ))
 }
 
-pub(crate) fn write_parquet(array: FixedSizeListArray) -> Result<Bytes, Box<dyn Error>> {
+/// Serializes a three-dimensional array to an in-memory Parquet file.
+///
+/// Uses the default non-nullable `features` field; call
+/// [`write_parquet_with_field`] to control the schema.
+///
+/// # Errors
+/// Returns [`FixtureError::Arrow`] if the array does not match the schema, or
+/// [`FixtureError::Parquet`] if serialization fails.
+pub(crate) fn write_parquet(array: FixedSizeListArray) -> Result<Bytes, FixtureError> {
     let field = feature_field(3, false, false)?;
     write_parquet_with_field(field, array)
 }
 
+/// Serializes a single array to an in-memory Parquet file under `field`.
+///
+/// `array` must match `field`'s declared type and nullability.
+///
+/// # Errors
+/// Returns [`FixtureError::Arrow`] if the array does not match the schema, or
+/// [`FixtureError::Parquet`] if serialization fails.
 pub(crate) fn write_parquet_with_field(
     field: Field,
     array: FixedSizeListArray,
-) -> Result<Bytes, Box<dyn Error>> {
-    let schema = Arc::new(Schema::new(vec![field.clone()]));
+) -> Result<Bytes, FixtureError> {
+    let schema = Arc::new(Schema::new(vec![field]));
     let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(array) as ArrayRef])?;
     let mut buffer = Vec::new();
     {
@@ -149,11 +250,19 @@ pub(crate) fn write_parquet_with_field(
     Ok(Bytes::from(buffer))
 }
 
+/// Serializes two arrays as separate row groups of one Parquet file.
+///
+/// Both arrays share `field`, exercising multi-batch ingest paths. Each must
+/// match `field`'s declared type and nullability.
+///
+/// # Errors
+/// Returns [`FixtureError::Arrow`] if either array does not match the schema,
+/// or [`FixtureError::Parquet`] if serialization fails.
 pub(crate) fn write_parquet_two_batches(
     first: FixedSizeListArray,
     second: FixedSizeListArray,
     field: Field,
-) -> Result<Bytes, Box<dyn Error>> {
+) -> Result<Bytes, FixtureError> {
     let schema = Arc::new(Schema::new(vec![field]));
     let batch_one = RecordBatch::try_new(schema.clone(), vec![Arc::new(first) as ArrayRef])?;
     let batch_two = RecordBatch::try_new(schema.clone(), vec![Arc::new(second) as ArrayRef])?;
@@ -167,11 +276,15 @@ pub(crate) fn write_parquet_two_batches(
     Ok(Bytes::from(buffer))
 }
 
+/// Wraps a flat value array as a fixed-size list with the given stride.
+///
+/// # Errors
+/// Returns [`FixtureError::Dimension`] if `dimension` exceeds `i32`.
 fn fixed_size_list_from_values(
     values: Float32Array,
     dimension: usize,
     child_nullable: bool,
-) -> Result<FixedSizeListArray, Box<dyn Error>> {
+) -> Result<FixedSizeListArray, FixtureError> {
     Ok(FixedSizeListArray::new(
         Arc::new(Field::new("item", DataType::Float32, child_nullable)),
         i32::try_from(dimension)?,


### PR DESCRIPTION
## Summary

This branch clears every `no_expect_outside_tests` finding that Whitaker
suite v0.2.7 raises against the repository, restoring a green `make lint`
now that CI resolves the latest installer release instead of pinning
v0.2.6.

Closes #193.

Suite v0.2.7 enforces the finding against test helper and fixture
functions that the former 0.2.6 pin never checked: 44 findings across
`chutoro-core` (29) and `chutoro-providers-dense` (15). The branch applies
the house policy that fixtures and helpers are not tests: each flagged
helper becomes fallible and propagates errors, while recognized `#[test]`,
`#[rstest]`, and `proptest!` bodies consume the `Result` with
`.expect(...)`, keeping the original message text. No production code is
touched.

## Review walkthrough

- Start with [chutoro-core/src/session/tests/common.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-core/src/session/tests/common.rs)
  for the canonical shape: `make_session` and `harvest_expected_edges`
  return domain-error `Result`s and every test body unwraps with the old
  message.
- [chutoro-core/src/session/tests/core_distance_support.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-core/src/session/tests/core_distance_support.rs)
  and [budget_types.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_types.rs)
  are new modules extracted verbatim after the refactor pushed
  `core_distance.rs` and `budget_selection.rs` just past the 400-line
  `module_max_lines` cap; `budget_selection` re-exports the moved types so
  consumers are unchanged.
- [budget_selection.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-core/src/hnsw/tests/property/test_runner_support/budget_selection.rs)
  also drops the panicking `TestCases::new`/`StackSize::new` wrappers in
  favour of the existing `try_new` forms.
- Proptest contexts ([search_property.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-core/src/hnsw/tests/property/search_property.rs),
  [edge_harvest_property.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-core/src/hnsw/tests/property/edge_harvest_property.rs))
  map failures through `TestCaseError::fail`, matching the surrounding
  style.
- In `chutoro-providers-dense`, [src/tests/support.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-providers/dense/src/tests/support.rs)
  makes the Arrow/Parquet fixture builders return
  `Result<_, Box<dyn Error>>`, and [src/simd/tests/parity/mod.rs](https://github.com/leynos/chutoro/blob/8b9141f6bd329a11ed36527ada84f0ca9310acfc/chutoro-providers/dense/src/simd/tests/parity/mod.rs)
  converts the backend enumerators to `Result<_, String>` so a missing
  kernel entry point fails the calling test instead of panicking in a
  helper.

## Validation

- `make lint-whitaker`: pass, zero findings
  (`/tmp/lint-whitaker-chutoro-issue-193-round3.out`)
- `make check-fmt` / `make lint-clippy` / `make typecheck`: pass
  (`/tmp/<gate>-chutoro-issue-193.out`)
- `make test`: pass — 1085 tests passed, 1 skipped
  (`/tmp/test-chutoro-issue-193.out`)
- `make markdownlint` (incl. spelling), `make nixie`,
  `make test-workflow-contracts`: pass

## Notes

- The findings surfaced when CI stopped pinning the Whitaker installer at
  v0.2.6 (fdc42fb); the 0.2.6 suite never checked these helpers.
- `observed_cores` returns `Option<Vec<f32>>` rather than `Result` — a
  missing core distance is a query outcome, not an error, and the `Option`
  collect is the natural shape.

## Summary by Sourcery

Make test helper and fixture utilities fallible and propagate errors to satisfy Whitaker lint rules, while keeping production code unchanged.

Bug Fixes:
- Ensure test-only HNSW graph and distance cache helpers handle invalid parameters via Result instead of panicking.
- Have SIMD parity tests report missing backend kernel entry points as test failures instead of panics.

Enhancements:
- Extract reusable budget-type newtypes into a dedicated module for HNSW property test runner configuration.
- Factor core-distance batch oracle and helper logic into a separate support module to keep core-distance tests focused on behavior.

Tests:
- Update session, HNSW, and dense-provider tests to unwrap new fallible helpers explicitly, preserving existing assertion messages.
- Adjust property-test runners and fixtures to consume Result-returning helpers and to surface configuration errors via TestCaseError.

## Review round two

Addressed reviewer feedback on the fixture helpers:

- The HNSW trimming fixtures now return a `TrimmingFixtureError` enum
  instead of `Box<dyn Error>`, keeping `HnswError` intact and naming the
  fixture invariants (`MissingTrimJob`, `MissingNode`) separately.
- `build_trimming_test_graph` drops its unused `new_node_id` parameter
  and the `let _ = new_node_id;` discard; its sole caller is updated.
- The dense Arrow/Parquet fixtures return a `FixtureError` enum covering
  row-length, dimension, Arrow, and Parquet failures. The row-length
  `assert!`s become `Err` returns, so the builders are fallible
  throughout as the module header already claimed, and the redundant
  `field.clone()` in `write_parquet_with_field` is gone.
- `select_mutation_cases_for_fork` uses sequential early returns behind
  a named `should_preserve_forked_budget` predicate, with `fork` renamed
  to `is_forked`. Behaviour is unchanged.
- Added Rustdoc to the parent-visible items in
  `session/tests/common.rs` and to the eight dense fixture builders.

Gates re-run and green: `check-fmt`, `lint` (clippy, Whitaker, cargo
doc), `typecheck`, `test` (1085 passed, 1 skipped), `markdownlint`,
`nixie`.

## References

- [Lody session](https://lody.ai/leynos/sessions/71cc4d3d-f8b0-4af8-bd74-5c2f976889a9)
- [Issue #193](https://github.com/leynos/chutoro/issues/193)
